### PR TITLE
Revise README to reflect current registration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 https://openci.org
 
-a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-v2 is out! Easier to self-host.
-
 New registration is closed.
 
 See: https://openci.org

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 https://openci.org
-
-a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 New registration is closed.
 
 https://openci.org
-
-Docs: WIP

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 https://openci.org
 
+a

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
-New registration is closed.
-
 https://openci.org

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 https://openci.org
 
+
+a

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 https://openci.org
+
+a

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 https://openci.org
 
-
-a

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 New registration is closed.
 
-See: https://openci.org
+https://openci.org
 
 Docs: WIP


### PR DESCRIPTION
Removed announcement for v2 release and updated registration status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * READMEの先頭表示を更新しました。  
  * 「v2 is out」「新規登録停止」「Docs: WIP」などの旧告知ブロックを削除しました。  
  * 案内URLの表示を単体URL表記に簡略化し、先頭を整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->