### PR TITLE
feat(i18n): add Japanese localization support and implement language switching

### DIFF
--- a/apps/genuineci_cli/bin/genuineci_cli.dart
+++ b/apps/genuineci_cli/bin/genuineci_cli.dart
@@ -4,6 +4,8 @@ import 'package:args/command_runner.dart';
 import 'package:genuineci_cli/genuineci_cli.dart';
 
 Future<void> main(List<String> arguments) async {
+  initI18n();
+
   final runner = GenuineCiCommandRunner();
   try {
     final exitCode = await runner.run(arguments);

--- a/apps/genuineci_cli/lib/genuineci_cli.dart
+++ b/apps/genuineci_cli/lib/genuineci_cli.dart
@@ -2,3 +2,6 @@ library;
 
 export 'src/command_runner.dart';
 export 'src/commands/login_command.dart';
+export 'src/commands/use_command.dart';
+export 'src/config/cli_config.dart';
+export 'src/i18n/i18n.dart';

--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -1,0 +1,29 @@
+{
+  "cli": {
+    "description": "GenuineCI command-line tool for managing CI/CD and secrets.",
+    "version": "genuineci version: ${version}",
+    "flags": {
+      "version": "Print the current tool version.",
+      "verbose": "Enable verbose logging output."
+    }
+  },
+  "login": {
+    "description": "Log in to GenuineCI server (Local or Cloud).",
+    "flags": {
+      "local": "Log in to local Docker environment (http://localhost:8080).",
+      "server": "Server base URL.",
+      "teamId": "Target team ID.",
+      "profile": "Profile name to store credentials under."
+    },
+    "loggingIn": "Logging in to GenuineCI...",
+    "savedSuccess": "Successfully saved credentials for profile \"${profile}\"."
+  },
+  "use": {
+    "description": "Set the default display language (japanese, english).",
+    "success": "Language set to ${language}.",
+    "invalidLanguage": "Invalid language \"${input}\". Supported languages: japanese, english."
+  },
+  "common": {
+    "error": "Error: ${error}"
+  }
+}

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -1,0 +1,29 @@
+{
+  "cli": {
+    "description": "GenuineCI - CI/CD およびシークレット管理コマンドラインツール",
+    "version": "genuineci バージョン: ${version}",
+    "flags": {
+      "version": "ツールのバージョンを表示します。",
+      "verbose": "詳細なログ出力を有効にします。"
+    }
+  },
+  "login": {
+    "description": "GenuineCI サーバー（ローカルまたはクラウド）にログインします。",
+    "flags": {
+      "local": "ローカルDocker環境（http://localhost:8080）に接続します。",
+      "server": "接続先サーバーURL。",
+      "teamId": "対象のチームID。",
+      "profile": "認証情報を保存するプロファイル名。"
+    },
+    "loggingIn": "GenuineCI にログイン中...",
+    "savedSuccess": "プロファイル「${profile}」の認証情報を保存しました。"
+  },
+  "use": {
+    "description": "表示言語を設定します（japanese, english）。",
+    "success": "言語を${language}に設定しました。",
+    "invalidLanguage": "無効な言語です: 「${input}」。対応言語: japanese, english"
+  },
+  "common": {
+    "error": "エラー: ${error}"
+  }
+}

--- a/apps/genuineci_cli/lib/i18n/strings.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings.g.dart
@@ -1,0 +1,183 @@
+/// Generated file. Do not edit.
+///
+/// Source: lib/i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 2
+/// Strings: 24 (12 per locale)
+///
+/// Built on 2026-08-28 at 12:45 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang_flutter/slang_flutter.dart';
+export 'package:slang_flutter/slang_flutter.dart';
+
+import 'strings_ja.g.dart' deferred as l_ja;
+part 'strings_en.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.en) // set locale
+/// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	en(languageCode: 'en'),
+	ja(languageCode: 'ja');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.ja:
+				await l_ja.loadLibrary();
+				return l_ja.TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.ja:
+				return l_ja.TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Method B: Advanced
+///
+/// All widgets using this method will trigger a rebuild when locale changes.
+/// Use this if you have e.g. a settings page where the user can select the locale during runtime.
+///
+/// Step 1:
+/// wrap your App with
+/// TranslationProvider(
+/// 	child: MyApp()
+/// );
+///
+/// Step 2:
+/// final t = Translations.of(context); // Get t variable.
+/// String a = t.someKey.anotherKey; // Use t variable.
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
+
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
+}
+
+/// Method B shorthand via [BuildContext] extension method.
+/// Configurable via 'translate_var'.
+///
+/// Usage (e.g. in a widget's build method):
+/// context.t.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+	Translations get t => TranslationProvider.of(this).translations;
+}
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: true,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/apps/genuineci_cli/lib/i18n/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings_en.g.dart
@@ -1,0 +1,156 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final Translations$cli$en cli = Translations$cli$en._(_root);
+	late final Translations$login$en login = Translations$login$en._(_root);
+	late final Translations$common$en common = Translations$common$en._(_root);
+}
+
+// Path: cli
+class Translations$cli$en {
+	Translations$cli$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'GenuineCI command-line tool for managing CI/CD and secrets.'
+	String get description => 'GenuineCI command-line tool for managing CI/CD and secrets.';
+
+	/// en: 'genuineci version: ${version}'
+	String version({required Object version}) => 'genuineci version: ${version}';
+
+	late final Translations$cli$flags$en flags = Translations$cli$flags$en._(_root);
+}
+
+// Path: login
+class Translations$login$en {
+	Translations$login$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log in to GenuineCI server (Local or Cloud).'
+	String get description => 'Log in to GenuineCI server (Local or Cloud).';
+
+	late final Translations$login$flags$en flags = Translations$login$flags$en._(_root);
+
+	/// en: 'Logging in to GenuineCI...'
+	String get loggingIn => 'Logging in to GenuineCI...';
+
+	/// en: 'Successfully saved credentials for profile "${profile}".'
+	String savedSuccess({required Object profile}) => 'Successfully saved credentials for profile "${profile}".';
+}
+
+// Path: common
+class Translations$common$en {
+	Translations$common$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Error: ${error}'
+	String error({required Object error}) => 'Error: ${error}';
+}
+
+// Path: cli.flags
+class Translations$cli$flags$en {
+	Translations$cli$flags$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Print the current tool version.'
+	String get version => 'Print the current tool version.';
+
+	/// en: 'Enable verbose logging output.'
+	String get verbose => 'Enable verbose logging output.';
+}
+
+// Path: login.flags
+class Translations$login$flags$en {
+	Translations$login$flags$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log in to local Docker environment (http://localhost:8080).'
+	String get local => 'Log in to local Docker environment (http://localhost:8080).';
+
+	/// en: 'Server base URL.'
+	String get server => 'Server base URL.';
+
+	/// en: 'Target team ID.'
+	String get teamId => 'Target team ID.';
+
+	/// en: 'Profile name to store credentials under.'
+	String get profile => 'Profile name to store credentials under.';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'cli.description' => 'GenuineCI command-line tool for managing CI/CD and secrets.',
+			'cli.version' => ({required Object version}) => 'genuineci version: ${version}',
+			'cli.flags.version' => 'Print the current tool version.',
+			'cli.flags.verbose' => 'Enable verbose logging output.',
+			'login.description' => 'Log in to GenuineCI server (Local or Cloud).',
+			'login.flags.local' => 'Log in to local Docker environment (http://localhost:8080).',
+			'login.flags.server' => 'Server base URL.',
+			'login.flags.teamId' => 'Target team ID.',
+			'login.flags.profile' => 'Profile name to store credentials under.',
+			'login.loggingIn' => 'Logging in to GenuineCI...',
+			'login.savedSuccess' => ({required Object profile}) => 'Successfully saved credentials for profile "${profile}".',
+			'common.error' => ({required Object error}) => 'Error: ${error}',
+			_ => null,
+		};
+	}
+}

--- a/apps/genuineci_cli/lib/i18n/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings_ja.g.dart
@@ -1,0 +1,127 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsJa with BaseTranslations<AppLocale, Translations> implements Translations {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsJa({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.ja,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <ja>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final TranslationsJa _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsJa $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsJa(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _Translations$cli$ja cli = _Translations$cli$ja._(_root);
+	@override late final _Translations$login$ja login = _Translations$login$ja._(_root);
+	@override late final _Translations$common$ja common = _Translations$common$ja._(_root);
+}
+
+// Path: cli
+class _Translations$cli$ja implements Translations$cli$en {
+	_Translations$cli$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => 'GenuineCI - CI/CD およびシークレット管理コマンドラインツール';
+	@override String version({required Object version}) => 'genuineci バージョン: ${version}';
+	@override late final _Translations$cli$flags$ja flags = _Translations$cli$flags$ja._(_root);
+}
+
+// Path: login
+class _Translations$login$ja implements Translations$login$en {
+	_Translations$login$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => 'GenuineCI サーバー（ローカルまたはクラウド）にログインします。';
+	@override late final _Translations$login$flags$ja flags = _Translations$login$flags$ja._(_root);
+	@override String get loggingIn => 'GenuineCI にログイン中...';
+	@override String savedSuccess({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。';
+}
+
+// Path: common
+class _Translations$common$ja implements Translations$common$en {
+	_Translations$common$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String error({required Object error}) => 'エラー: ${error}';
+}
+
+// Path: cli.flags
+class _Translations$cli$flags$ja implements Translations$cli$flags$en {
+	_Translations$cli$flags$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get version => 'ツールのバージョンを表示します。';
+	@override String get verbose => '詳細なログ出力を有効にします。';
+}
+
+// Path: login.flags
+class _Translations$login$flags$ja implements Translations$login$flags$en {
+	_Translations$login$flags$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get local => 'ローカルDocker環境（http://localhost:8080）に接続します。';
+	@override String get server => '接続先サーバーURL。';
+	@override String get teamId => '対象のチームID。';
+	@override String get profile => '認証情報を保存するプロファイル名。';
+}
+
+/// The flat map containing all translations for locale <ja>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsJa {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'cli.description' => 'GenuineCI - CI/CD およびシークレット管理コマンドラインツール',
+			'cli.version' => ({required Object version}) => 'genuineci バージョン: ${version}',
+			'cli.flags.version' => 'ツールのバージョンを表示します。',
+			'cli.flags.verbose' => '詳細なログ出力を有効にします。',
+			'login.description' => 'GenuineCI サーバー（ローカルまたはクラウド）にログインします。',
+			'login.flags.local' => 'ローカルDocker環境（http://localhost:8080）に接続します。',
+			'login.flags.server' => '接続先サーバーURL。',
+			'login.flags.teamId' => '対象のチームID。',
+			'login.flags.profile' => '認証情報を保存するプロファイル名。',
+			'login.loggingIn' => 'GenuineCI にログイン中...',
+			'login.savedSuccess' => ({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。',
+			'common.error' => ({required Object error}) => 'エラー: ${error}',
+			_ => null,
+		};
+	}
+}

--- a/apps/genuineci_cli/lib/src/command_runner.dart
+++ b/apps/genuineci_cli/lib/src/command_runner.dart
@@ -1,38 +1,36 @@
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
 
 import 'commands/login_command.dart';
+import 'commands/use_command.dart';
+import 'i18n/i18n.dart';
 
 const String genuineCiVersion = '0.0.1';
 
 class GenuineCiCommandRunner extends CommandRunner<int> {
-  GenuineCiCommandRunner()
-    : super(
-        'genuineci',
-        'GenuineCI command-line tool for managing CI/CD and secrets.',
-      ) {
+  final Logger _logger;
+
+  GenuineCiCommandRunner({Logger? logger})
+    : _logger = logger ?? Logger(),
+      super('genuineci', t.cli.description) {
     argParser
       ..addFlag(
         'version',
         abbr: 'v',
         negatable: false,
-        help: 'Print the current tool version.',
+        help: t.cli.flags.version,
       )
-      ..addFlag(
-        'verbose',
-        negatable: false,
-        help: 'Enable verbose logging output.',
-      );
+      ..addFlag('verbose', negatable: false, help: t.cli.flags.verbose);
 
     addCommand(LoginCommand());
+    addCommand(UseCommand(logger: _logger));
   }
 
   @override
   Future<int?> runCommand(ArgResults topLevelResults) async {
     if (topLevelResults['version'] == true) {
-      stdout.writeln('genuineci version: $genuineCiVersion');
+      _logger.info(t.cli.version(version: genuineCiVersion));
       return 0;
     }
     return await super.runCommand(topLevelResults);

--- a/apps/genuineci_cli/lib/src/commands/login_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/login_command.dart
@@ -1,27 +1,20 @@
 import 'package:args/command_runner.dart';
 
+import '../i18n/i18n.dart';
+
 class LoginCommand extends Command<int> {
   @override
   final String name = 'login';
 
   @override
-  final String description = 'Log in to GenuineCI server (Local or Cloud).';
+  String get description => t.login.description;
 
   LoginCommand() {
     argParser
-      ..addFlag(
-        'local',
-        abbr: 'l',
-        negatable: false,
-        help: 'Log in to local Docker environment (http://localhost:8080).',
-      )
-      ..addOption('server', abbr: 's', help: 'Server base URL.')
-      ..addOption('team-id', abbr: 't', help: 'Target team ID.')
-      ..addOption(
-        'profile',
-        abbr: 'p',
-        help: 'Profile name to store credentials under.',
-      );
+      ..addFlag('local', abbr: 'l', negatable: false, help: t.login.flags.local)
+      ..addOption('server', abbr: 's', help: t.login.flags.server)
+      ..addOption('team-id', abbr: 't', help: t.login.flags.teamId)
+      ..addOption('profile', abbr: 'p', help: t.login.flags.profile);
   }
 
   @override

--- a/apps/genuineci_cli/lib/src/commands/use_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/use_command.dart
@@ -1,0 +1,53 @@
+import 'package:args/command_runner.dart';
+import 'package:mason_logger/mason_logger.dart';
+
+import '../config/cli_config.dart';
+import '../i18n/i18n.dart';
+
+class UseCommand extends Command<int> {
+  @override
+  final String name = 'use';
+
+  @override
+  String get description => t.use.description;
+
+  final CliConfig _config;
+  final Logger _logger;
+
+  UseCommand({CliConfig? config, Logger? logger})
+    : _config = config ?? CliConfig(),
+      _logger = logger ?? Logger();
+
+  @override
+  Future<int> run() async {
+    final rest = argResults?.rest ?? [];
+    if (rest.isEmpty) {
+      _logger.err('Usage: genuineci use <japanese|english>');
+      return 64; // EX_USAGE
+    }
+
+    final input = rest.first.toLowerCase().trim();
+    final String targetCode;
+    final String languageName;
+
+    switch (input) {
+      case 'japanese':
+        targetCode = 'ja';
+        languageName = 'Japanese';
+        break;
+      case 'english':
+        targetCode = 'en';
+        languageName = 'English';
+        break;
+      default:
+        _logger.err(t.use.invalidLanguage(input: input));
+        return 1;
+    }
+
+    _config.setLanguage(targetCode);
+    LocaleSettings.setLocaleSync(AppLocaleUtils.parse(targetCode));
+
+    _logger.success(t.use.success(language: languageName));
+    return 0;
+  }
+}

--- a/apps/genuineci_cli/lib/src/config/cli_config.dart
+++ b/apps/genuineci_cli/lib/src/config/cli_config.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+class CliConfig {
+  final String _filePath;
+
+  CliConfig({String? customFilePath})
+    : _filePath = customFilePath ?? _defaultConfigPath();
+
+  static String _defaultConfigPath() {
+    final home =
+        Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'] ??
+        Directory.current.path;
+    return p.join(home, '.genuineci', 'config.json');
+  }
+
+  Map<String, dynamic> _readSync() {
+    final file = File(_filePath);
+    if (!file.existsSync()) {
+      return {};
+    }
+    try {
+      final content = file.readAsStringSync();
+      if (content.trim().isEmpty) return {};
+      return jsonDecode(content) as Map<String, dynamic>;
+    } catch (_) {
+      return {};
+    }
+  }
+
+  void _writeSync(Map<String, dynamic> data) {
+    final file = File(_filePath);
+    final dir = file.parent;
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+    const encoder = JsonEncoder.withIndent('  ');
+    file.writeAsStringSync('${encoder.convert(data)}\n');
+  }
+
+  /// Gets the configured language code (e.g. 'ja', 'en') or null.
+  String? getLanguage() {
+    final data = _readSync();
+    return data['language'] as String?;
+  }
+
+  /// Sets and saves the language code.
+  void setLanguage(String languageCode) {
+    final data = _readSync();
+    data['language'] = languageCode;
+    _writeSync(data);
+  }
+}

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -1,0 +1,138 @@
+/// Generated file. Do not edit.
+///
+/// Source: lib/i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 2
+/// Strings: 30 (15 per locale)
+///
+/// Built on 2026-08-28 at 12:55 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang/slang.dart';
+export 'package:slang/slang.dart';
+
+import 'strings_ja.g.dart' as l_ja;
+part 'strings_en.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.en) // set locale
+/// - Locale locale = AppLocale.en.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.en) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	en(languageCode: 'en'),
+	ja(languageCode: 'ja');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		return buildSync(
+			overrides: overrides,
+			cardinalResolver: cardinalResolver,
+			ordinalResolver: ordinalResolver,
+		);
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.en:
+				return TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.ja:
+				return l_ja.TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: false,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.en,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -1,0 +1,172 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsEn = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final Translations$cli$en cli = Translations$cli$en.internal(_root);
+	late final Translations$login$en login = Translations$login$en.internal(_root);
+	late final Translations$use$en use = Translations$use$en.internal(_root);
+	late final Translations$common$en common = Translations$common$en.internal(_root);
+}
+
+// Path: cli
+class Translations$cli$en {
+	Translations$cli$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'GenuineCI command-line tool for managing CI/CD and secrets.'
+	String get description => 'GenuineCI command-line tool for managing CI/CD and secrets.';
+
+	/// en: 'genuineci version: ${version}'
+	String version({required Object version}) => 'genuineci version: ${version}';
+
+	late final Translations$cli$flags$en flags = Translations$cli$flags$en.internal(_root);
+}
+
+// Path: login
+class Translations$login$en {
+	Translations$login$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log in to GenuineCI server (Local or Cloud).'
+	String get description => 'Log in to GenuineCI server (Local or Cloud).';
+
+	late final Translations$login$flags$en flags = Translations$login$flags$en.internal(_root);
+
+	/// en: 'Logging in to GenuineCI...'
+	String get loggingIn => 'Logging in to GenuineCI...';
+
+	/// en: 'Successfully saved credentials for profile "${profile}".'
+	String savedSuccess({required Object profile}) => 'Successfully saved credentials for profile "${profile}".';
+}
+
+// Path: use
+class Translations$use$en {
+	Translations$use$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Set the default display language (japanese, english).'
+	String get description => 'Set the default display language (japanese, english).';
+
+	/// en: 'Language set to ${language}.'
+	String success({required Object language}) => 'Language set to ${language}.';
+
+	/// en: 'Invalid language "${input}". Supported languages: japanese, english.'
+	String invalidLanguage({required Object input}) => 'Invalid language "${input}". Supported languages: japanese, english.';
+}
+
+// Path: common
+class Translations$common$en {
+	Translations$common$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Error: ${error}'
+	String error({required Object error}) => 'Error: ${error}';
+}
+
+// Path: cli.flags
+class Translations$cli$flags$en {
+	Translations$cli$flags$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Print the current tool version.'
+	String get version => 'Print the current tool version.';
+
+	/// en: 'Enable verbose logging output.'
+	String get verbose => 'Enable verbose logging output.';
+}
+
+// Path: login.flags
+class Translations$login$flags$en {
+	Translations$login$flags$en.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Log in to local Docker environment (http://localhost:8080).'
+	String get local => 'Log in to local Docker environment (http://localhost:8080).';
+
+	/// en: 'Server base URL.'
+	String get server => 'Server base URL.';
+
+	/// en: 'Target team ID.'
+	String get teamId => 'Target team ID.';
+
+	/// en: 'Profile name to store credentials under.'
+	String get profile => 'Profile name to store credentials under.';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'cli.description' => 'GenuineCI command-line tool for managing CI/CD and secrets.',
+			'cli.version' => ({required Object version}) => 'genuineci version: ${version}',
+			'cli.flags.version' => 'Print the current tool version.',
+			'cli.flags.verbose' => 'Enable verbose logging output.',
+			'login.description' => 'Log in to GenuineCI server (Local or Cloud).',
+			'login.flags.local' => 'Log in to local Docker environment (http://localhost:8080).',
+			'login.flags.server' => 'Server base URL.',
+			'login.flags.teamId' => 'Target team ID.',
+			'login.flags.profile' => 'Profile name to store credentials under.',
+			'login.loggingIn' => 'Logging in to GenuineCI...',
+			'login.savedSuccess' => ({required Object profile}) => 'Successfully saved credentials for profile "${profile}".',
+			'use.description' => 'Set the default display language (japanese, english).',
+			'use.success' => ({required Object language}) => 'Language set to ${language}.',
+			'use.invalidLanguage' => ({required Object input}) => 'Invalid language "${input}". Supported languages: japanese, english.',
+			'common.error' => ({required Object error}) => 'Error: ${error}',
+			_ => null,
+		};
+	}
+}

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -1,0 +1,144 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsJa extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsJa({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.ja,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <ja>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsJa _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsJa $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsJa(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _Translations$cli$ja cli = _Translations$cli$ja._(_root);
+	@override late final _Translations$login$ja login = _Translations$login$ja._(_root);
+	@override late final _Translations$use$ja use = _Translations$use$ja._(_root);
+	@override late final _Translations$common$ja common = _Translations$common$ja._(_root);
+}
+
+// Path: cli
+class _Translations$cli$ja extends Translations$cli$en {
+	_Translations$cli$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => 'GenuineCI - CI/CD およびシークレット管理コマンドラインツール';
+	@override String version({required Object version}) => 'genuineci バージョン: ${version}';
+	@override late final _Translations$cli$flags$ja flags = _Translations$cli$flags$ja._(_root);
+}
+
+// Path: login
+class _Translations$login$ja extends Translations$login$en {
+	_Translations$login$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => 'GenuineCI サーバー（ローカルまたはクラウド）にログインします。';
+	@override late final _Translations$login$flags$ja flags = _Translations$login$flags$ja._(_root);
+	@override String get loggingIn => 'GenuineCI にログイン中...';
+	@override String savedSuccess({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。';
+}
+
+// Path: use
+class _Translations$use$ja extends Translations$use$en {
+	_Translations$use$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '表示言語を設定します（japanese, english）。';
+	@override String success({required Object language}) => '言語を${language}に設定しました。';
+	@override String invalidLanguage({required Object input}) => '無効な言語です: 「${input}」。対応言語: japanese, english';
+}
+
+// Path: common
+class _Translations$common$ja extends Translations$common$en {
+	_Translations$common$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String error({required Object error}) => 'エラー: ${error}';
+}
+
+// Path: cli.flags
+class _Translations$cli$flags$ja extends Translations$cli$flags$en {
+	_Translations$cli$flags$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get version => 'ツールのバージョンを表示します。';
+	@override String get verbose => '詳細なログ出力を有効にします。';
+}
+
+// Path: login.flags
+class _Translations$login$flags$ja extends Translations$login$flags$en {
+	_Translations$login$flags$ja._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get local => 'ローカルDocker環境（http://localhost:8080）に接続します。';
+	@override String get server => '接続先サーバーURL。';
+	@override String get teamId => '対象のチームID。';
+	@override String get profile => '認証情報を保存するプロファイル名。';
+}
+
+/// The flat map containing all translations for locale <ja>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsJa {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'cli.description' => 'GenuineCI - CI/CD およびシークレット管理コマンドラインツール',
+			'cli.version' => ({required Object version}) => 'genuineci バージョン: ${version}',
+			'cli.flags.version' => 'ツールのバージョンを表示します。',
+			'cli.flags.verbose' => '詳細なログ出力を有効にします。',
+			'login.description' => 'GenuineCI サーバー（ローカルまたはクラウド）にログインします。',
+			'login.flags.local' => 'ローカルDocker環境（http://localhost:8080）に接続します。',
+			'login.flags.server' => '接続先サーバーURL。',
+			'login.flags.teamId' => '対象のチームID。',
+			'login.flags.profile' => '認証情報を保存するプロファイル名。',
+			'login.loggingIn' => 'GenuineCI にログイン中...',
+			'login.savedSuccess' => ({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。',
+			'use.description' => '表示言語を設定します（japanese, english）。',
+			'use.success' => ({required Object language}) => '言語を${language}に設定しました。',
+			'use.invalidLanguage' => ({required Object input}) => '無効な言語です: 「${input}」。対応言語: japanese, english',
+			'common.error' => ({required Object error}) => 'エラー: ${error}',
+			_ => null,
+		};
+	}
+}

--- a/apps/genuineci_cli/lib/src/i18n/i18n.dart
+++ b/apps/genuineci_cli/lib/src/i18n/i18n.dart
@@ -1,0 +1,17 @@
+import '../config/cli_config.dart';
+import '../gen/strings.g.dart';
+
+export '../gen/strings.g.dart';
+
+/// Initializes i18n / slang translations.
+/// Defaults to English, unless Japanese ('ja') is configured.
+void initI18n({CliConfig? config}) {
+  final cliConfig = config ?? CliConfig();
+  final configuredLang = cliConfig.getLanguage();
+
+  if (configuredLang == 'ja') {
+    LocaleSettings.setLocaleSync(AppLocale.ja);
+  } else {
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  }
+}

--- a/apps/genuineci_cli/pubspec.yaml
+++ b/apps/genuineci_cli/pubspec.yaml
@@ -11,9 +11,14 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   args: ^2.7.0
+  mason_logger: ^0.3.4
+  path: ^1.9.0
+  slang: ^4.19.0
 
 dev_dependencies:
+  build_runner: ^2.16.0
   lints: ^6.0.0
+  slang_build_runner: ^4.19.0
   test: ^1.25.6
 
 executables:

--- a/apps/genuineci_cli/slang.yaml
+++ b/apps/genuineci_cli/slang.yaml
@@ -1,0 +1,6 @@
+base_locale: en
+fallback_strategy: base_locale
+input_directory: lib/i18n
+output_directory: lib/src/gen
+flutter_integration: false
+lazy: false

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner
-      sha256: be46e59dcfefd6c6c7127df9f1be6c1f89219fee22ae02a923463e0f286ce652
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.2"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -941,6 +941,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.3.1"
+  mason_logger:
+    dependency: transitive
+    description:
+      name: mason_logger
+      sha256: "4f053e4e7e1716002b72cad133d81612be3550d40ed9d43c1878c9b03ba93069"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4"
   matcher:
     dependency: transitive
     description:
@@ -1317,6 +1325,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.27.0"
+  serial_csv:
+    dependency: transitive
+    description:
+      name: serial_csv
+      sha256: "2d62bb70cb3ce7251383fc86ea9aae1298ab1e57af6ef4e93b6a9751c5c268dd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   shared_preferences:
     dependency: transitive
     description:
@@ -1434,6 +1450,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  slang:
+    dependency: transitive
+    description:
+      name: slang
+      sha256: "430749837528bb692b5ee03699fadab90d0d4a6dfbf42aab28e81df8da4c2fb8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.19.0"
+  slang_build_runner:
+    dependency: transitive
+    description:
+      name: slang_build_runner
+      sha256: f2b6c5fc1f5bc41de80b05e95e7d5d03b5c3041082877ce931fc7ba61cd08afe
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.19.0"
   source_gen:
     dependency: transitive
     description:


### PR DESCRIPTION


- Added Japanese translations in `ja.i18n.json` for CLI commands and messages.
- Generated localization files for English and Japanese using Slang.
- Implemented `UseCommand` to allow users to switch between Japanese and English.
- Created `CliConfig` to manage language settings and persist user preferences.
- Introduced `initI18n` function to initialize localization based on user configuration.
- Updated `slang.yaml` for localization generation settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * CLIの表示言語として日本語と英語に対応しました。
  * `genuineci use` コマンドで表示言語を切り替えられるようになりました。
  * 選択した言語を設定ファイルに保存し、次回起動時にも適用します。
  * CLIのコマンド説明、オプション、バージョン表示、エラーメッセージをローカライズしました。

* **改善**
  * ログ出力とエラーメッセージの表示を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->