### PR TITLE
feat(auth): implement credential store for managing user profiles and authentication

### DIFF
--- a/apps/genuineci_cli/lib/genuineci_cli.dart
+++ b/apps/genuineci_cli/lib/genuineci_cli.dart
@@ -1,5 +1,6 @@
 library;
 
+export 'src/auth/credential_store.dart';
 export 'src/command_runner.dart';
 export 'src/commands/login_command.dart';
 export 'src/commands/use_command.dart';

--- a/apps/genuineci_cli/lib/i18n/strings.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 24 (12 per locale)
+/// Strings: 30 (15 per locale)
 ///
-/// Built on 2026-08-28 at 12:45 UTC
+/// Built on 2026-08-28 at 13:42 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/i18n/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings_en.g.dart
@@ -42,6 +42,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	// Translations
 	late final Translations$cli$en cli = Translations$cli$en._(_root);
 	late final Translations$login$en login = Translations$login$en._(_root);
+	late final Translations$use$en use = Translations$use$en._(_root);
 	late final Translations$common$en common = Translations$common$en._(_root);
 }
 
@@ -80,6 +81,24 @@ class Translations$login$en {
 
 	/// en: 'Successfully saved credentials for profile "${profile}".'
 	String savedSuccess({required Object profile}) => 'Successfully saved credentials for profile "${profile}".';
+}
+
+// Path: use
+class Translations$use$en {
+	Translations$use$en._(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Set the default display language (japanese, english).'
+	String get description => 'Set the default display language (japanese, english).';
+
+	/// en: 'Language set to ${language}.'
+	String success({required Object language}) => 'Language set to ${language}.';
+
+	/// en: 'Invalid language "${input}". Supported languages: japanese, english.'
+	String invalidLanguage({required Object input}) => 'Invalid language "${input}". Supported languages: japanese, english.';
 }
 
 // Path: common
@@ -149,6 +168,9 @@ extension on Translations {
 			'login.flags.profile' => 'Profile name to store credentials under.',
 			'login.loggingIn' => 'Logging in to GenuineCI...',
 			'login.savedSuccess' => ({required Object profile}) => 'Successfully saved credentials for profile "${profile}".',
+			'use.description' => 'Set the default display language (japanese, english).',
+			'use.success' => ({required Object language}) => 'Language set to ${language}.',
+			'use.invalidLanguage' => ({required Object input}) => 'Invalid language "${input}". Supported languages: japanese, english.',
 			'common.error' => ({required Object error}) => 'Error: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/lib/i18n/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/i18n/strings_ja.g.dart
@@ -39,6 +39,7 @@ class TranslationsJa with BaseTranslations<AppLocale, Translations> implements T
 	// Translations
 	@override late final _Translations$cli$ja cli = _Translations$cli$ja._(_root);
 	@override late final _Translations$login$ja login = _Translations$login$ja._(_root);
+	@override late final _Translations$use$ja use = _Translations$use$ja._(_root);
 	@override late final _Translations$common$ja common = _Translations$common$ja._(_root);
 }
 
@@ -65,6 +66,18 @@ class _Translations$login$ja implements Translations$login$en {
 	@override late final _Translations$login$flags$ja flags = _Translations$login$flags$ja._(_root);
 	@override String get loggingIn => 'GenuineCI にログイン中...';
 	@override String savedSuccess({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。';
+}
+
+// Path: use
+class _Translations$use$ja implements Translations$use$en {
+	_Translations$use$ja._(this._root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get description => '表示言語を設定します（japanese, english）。';
+	@override String success({required Object language}) => '言語を${language}に設定しました。';
+	@override String invalidLanguage({required Object input}) => '無効な言語です: 「${input}」。対応言語: japanese, english';
 }
 
 // Path: common
@@ -120,6 +133,9 @@ extension on TranslationsJa {
 			'login.flags.profile' => '認証情報を保存するプロファイル名。',
 			'login.loggingIn' => 'GenuineCI にログイン中...',
 			'login.savedSuccess' => ({required Object profile}) => 'プロファイル「${profile}」の認証情報を保存しました。',
+			'use.description' => '表示言語を設定します（japanese, english）。',
+			'use.success' => ({required Object language}) => '言語を${language}に設定しました。',
+			'use.invalidLanguage' => ({required Object input}) => '無効な言語です: 「${input}」。対応言語: japanese, english',
 			'common.error' => ({required Object error}) => 'エラー: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/lib/src/auth/credential_store.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.dart
@@ -9,6 +9,8 @@ part 'credential_store.g.dart';
 
 @freezed
 abstract class AuthProfile with _$AuthProfile {
+  const AuthProfile._();
+
   const factory AuthProfile({
     @JsonKey(name: 'server_url')
     @Default('http://localhost:8080')
@@ -20,6 +22,12 @@ abstract class AuthProfile with _$AuthProfile {
 
   factory AuthProfile.fromJson(Map<String, dynamic> json) =>
       _$AuthProfileFromJson(json);
+
+  @override
+  String toString() {
+    final maskedToken = token.isEmpty ? '' : '***';
+    return 'AuthProfile(serverUrl: $serverUrl, token: $maskedToken, teamId: $teamId, authType: $authType)';
+  }
 }
 
 @freezed

--- a/apps/genuineci_cli/lib/src/auth/credential_store.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.dart
@@ -62,16 +62,17 @@ class CredentialStore {
     if (!await file.exists()) {
       return const CredentialConfig();
     }
-    try {
-      final content = await file.readAsString();
-      if (content.trim().isEmpty) {
-        return const CredentialConfig();
-      }
-      final json = jsonDecode(content) as Map<String, dynamic>;
-      return CredentialConfig.fromJson(json);
-    } catch (_) {
-      return const CredentialConfig();
+    final content = await file.readAsString();
+    if (content.trim().isEmpty) {
+      throw FormatException('Credential file at $_filePath is empty.');
     }
+    final json = jsonDecode(content);
+    if (json is! Map<String, dynamic>) {
+      throw FormatException(
+        'Invalid JSON format in credential file at $_filePath.',
+      );
+    }
+    return CredentialConfig.fromJson(json);
   }
 
   Future<void> save(CredentialConfig config) async {
@@ -81,7 +82,22 @@ class CredentialStore {
       await dir.create(recursive: true);
     }
     const encoder = JsonEncoder.withIndent('  ');
-    await file.writeAsString('${encoder.convert(config.toJson())}\n');
+    final content = '${encoder.convert(config.toJson())}\n';
+
+    final tempFile = File(
+      '${file.path}.tmp.${DateTime.now().microsecondsSinceEpoch}',
+    );
+    try {
+      await tempFile.writeAsString(content, flush: true);
+      await tempFile.rename(file.path);
+    } catch (_) {
+      if (await tempFile.exists()) {
+        try {
+          await tempFile.delete();
+        } catch (_) {}
+      }
+      rethrow;
+    }
   }
 
   Future<void> saveProfile(

--- a/apps/genuineci_cli/lib/src/auth/credential_store.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:path/path.dart' as p;
+
+part 'credential_store.freezed.dart';
+part 'credential_store.g.dart';
+
+@freezed
+abstract class AuthProfile with _$AuthProfile {
+  const factory AuthProfile({
+    @JsonKey(name: 'server_url')
+    @Default('http://localhost:8080')
+    String serverUrl,
+    @Default('') String token,
+    @JsonKey(name: 'team_id') @Default('') String teamId,
+    @JsonKey(name: 'auth_type') @Default('api_key') String authType,
+  }) = _AuthProfile;
+
+  factory AuthProfile.fromJson(Map<String, dynamic> json) =>
+      _$AuthProfileFromJson(json);
+}
+
+@freezed
+abstract class CredentialConfig with _$CredentialConfig {
+  const factory CredentialConfig({
+    @JsonKey(name: 'active_profile') @Default('default') String activeProfile,
+    @Default({}) Map<String, AuthProfile> profiles,
+  }) = _CredentialConfig;
+
+  factory CredentialConfig.fromJson(Map<String, dynamic> json) =>
+      _$CredentialConfigFromJson(json);
+}
+
+class CredentialStore {
+  final String _filePath;
+
+  CredentialStore({String? customFilePath})
+    : _filePath = customFilePath ?? _defaultCredentialsPath();
+
+  static String _defaultCredentialsPath() {
+    final home =
+        Platform.environment['HOME'] ??
+        Platform.environment['USERPROFILE'] ??
+        Directory.current.path;
+    return p.join(home, '.genuineci', 'credentials.json');
+  }
+
+  String get filePath => _filePath;
+
+  Future<CredentialConfig> load() async {
+    final file = File(_filePath);
+    if (!await file.exists()) {
+      return const CredentialConfig();
+    }
+    try {
+      final content = await file.readAsString();
+      if (content.trim().isEmpty) {
+        return const CredentialConfig();
+      }
+      final json = jsonDecode(content) as Map<String, dynamic>;
+      return CredentialConfig.fromJson(json);
+    } catch (_) {
+      return const CredentialConfig();
+    }
+  }
+
+  Future<void> save(CredentialConfig config) async {
+    final file = File(_filePath);
+    final dir = file.parent;
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    const encoder = JsonEncoder.withIndent('  ');
+    await file.writeAsString('${encoder.convert(config.toJson())}\n');
+  }
+
+  Future<void> saveProfile(
+    String name,
+    AuthProfile profile, {
+    bool setActive = true,
+  }) async {
+    final current = await load();
+    final updatedProfiles = Map<String, AuthProfile>.from(current.profiles);
+    updatedProfiles[name] = profile;
+
+    final updated = current.copyWith(
+      activeProfile: setActive ? name : current.activeProfile,
+      profiles: updatedProfiles,
+    );
+    await save(updated);
+  }
+
+  Future<AuthProfile?> getActiveProfile() async {
+    final current = await load();
+    return current.profiles[current.activeProfile];
+  }
+
+  Future<AuthProfile?> getProfile(String name) async {
+    final current = await load();
+    return current.profiles[name];
+  }
+
+  Future<bool> deleteProfile(String name) async {
+    final current = await load();
+    if (!current.profiles.containsKey(name)) {
+      return false;
+    }
+    final updatedProfiles = Map<String, AuthProfile>.from(current.profiles)
+      ..remove(name);
+    final nextActive = current.activeProfile == name
+        ? (updatedProfiles.keys.firstOrNull ?? 'default')
+        : current.activeProfile;
+
+    await save(
+      current.copyWith(activeProfile: nextActive, profiles: updatedProfiles),
+    );
+    return true;
+  }
+}

--- a/apps/genuineci_cli/lib/src/auth/credential_store.freezed.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.freezed.dart
@@ -35,10 +35,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,serverUrl,token,teamId,authType);
 
-@override
-String toString() {
-  return 'AuthProfile(serverUrl: $serverUrl, token: $token, teamId: $teamId, authType: $authType)';
-}
 
 
 }
@@ -211,8 +207,8 @@ return $default(_that.serverUrl,_that.token,_that.teamId,_that.authType);case _:
 /// @nodoc
 @JsonSerializable()
 
-class _AuthProfile implements AuthProfile {
-  const _AuthProfile({@JsonKey(name: 'server_url') this.serverUrl = 'http://localhost:8080', this.token = '', @JsonKey(name: 'team_id') this.teamId = '', @JsonKey(name: 'auth_type') this.authType = 'api_key'});
+class _AuthProfile extends AuthProfile {
+  const _AuthProfile({@JsonKey(name: 'server_url') this.serverUrl = 'http://localhost:8080', this.token = '', @JsonKey(name: 'team_id') this.teamId = '', @JsonKey(name: 'auth_type') this.authType = 'api_key'}): super._();
   factory _AuthProfile.fromJson(Map<String, dynamic> json) => _$AuthProfileFromJson(json);
 
 @override@JsonKey(name: 'server_url') final  String serverUrl;
@@ -240,10 +236,6 @@ bool operator ==(Object other) {
 @override
 int get hashCode => Object.hash(runtimeType,serverUrl,token,teamId,authType);
 
-@override
-String toString() {
-  return 'AuthProfile(serverUrl: $serverUrl, token: $token, teamId: $teamId, authType: $authType)';
-}
 
 
 }

--- a/apps/genuineci_cli/lib/src/auth/credential_store.freezed.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.freezed.dart
@@ -1,0 +1,558 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'credential_store.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AuthProfile {
+
+@JsonKey(name: 'server_url') String get serverUrl; String get token;@JsonKey(name: 'team_id') String get teamId;@JsonKey(name: 'auth_type') String get authType;
+/// Create a copy of AuthProfile
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AuthProfileCopyWith<AuthProfile> get copyWith => _$AuthProfileCopyWithImpl<AuthProfile>(this as AuthProfile, _$identity);
+
+  /// Serializes this AuthProfile to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthProfile&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.token, token) || other.token == token)&&(identical(other.teamId, teamId) || other.teamId == teamId)&&(identical(other.authType, authType) || other.authType == authType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,serverUrl,token,teamId,authType);
+
+@override
+String toString() {
+  return 'AuthProfile(serverUrl: $serverUrl, token: $token, teamId: $teamId, authType: $authType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AuthProfileCopyWith<$Res>  {
+  factory $AuthProfileCopyWith(AuthProfile value, $Res Function(AuthProfile) _then) = _$AuthProfileCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'server_url') String serverUrl, String token,@JsonKey(name: 'team_id') String teamId,@JsonKey(name: 'auth_type') String authType
+});
+
+
+
+
+}
+/// @nodoc
+class _$AuthProfileCopyWithImpl<$Res>
+    implements $AuthProfileCopyWith<$Res> {
+  _$AuthProfileCopyWithImpl(this._self, this._then);
+
+  final AuthProfile _self;
+  final $Res Function(AuthProfile) _then;
+
+/// Create a copy of AuthProfile
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? serverUrl = null,Object? token = null,Object? teamId = null,Object? authType = null,}) {
+  return _then(_self.copyWith(
+serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
+as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,teamId: null == teamId ? _self.teamId : teamId // ignore: cast_nullable_to_non_nullable
+as String,authType: null == authType ? _self.authType : authType // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [AuthProfile].
+extension AuthProfilePatterns on AuthProfile {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _AuthProfile value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _AuthProfile() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _AuthProfile value)  $default,){
+final _that = this;
+switch (_that) {
+case _AuthProfile():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _AuthProfile value)?  $default,){
+final _that = this;
+switch (_that) {
+case _AuthProfile() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'server_url')  String serverUrl,  String token, @JsonKey(name: 'team_id')  String teamId, @JsonKey(name: 'auth_type')  String authType)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _AuthProfile() when $default != null:
+return $default(_that.serverUrl,_that.token,_that.teamId,_that.authType);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'server_url')  String serverUrl,  String token, @JsonKey(name: 'team_id')  String teamId, @JsonKey(name: 'auth_type')  String authType)  $default,) {final _that = this;
+switch (_that) {
+case _AuthProfile():
+return $default(_that.serverUrl,_that.token,_that.teamId,_that.authType);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'server_url')  String serverUrl,  String token, @JsonKey(name: 'team_id')  String teamId, @JsonKey(name: 'auth_type')  String authType)?  $default,) {final _that = this;
+switch (_that) {
+case _AuthProfile() when $default != null:
+return $default(_that.serverUrl,_that.token,_that.teamId,_that.authType);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _AuthProfile implements AuthProfile {
+  const _AuthProfile({@JsonKey(name: 'server_url') this.serverUrl = 'http://localhost:8080', this.token = '', @JsonKey(name: 'team_id') this.teamId = '', @JsonKey(name: 'auth_type') this.authType = 'api_key'});
+  factory _AuthProfile.fromJson(Map<String, dynamic> json) => _$AuthProfileFromJson(json);
+
+@override@JsonKey(name: 'server_url') final  String serverUrl;
+@override@JsonKey() final  String token;
+@override@JsonKey(name: 'team_id') final  String teamId;
+@override@JsonKey(name: 'auth_type') final  String authType;
+
+/// Create a copy of AuthProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AuthProfileCopyWith<_AuthProfile> get copyWith => __$AuthProfileCopyWithImpl<_AuthProfile>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AuthProfileToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthProfile&&(identical(other.serverUrl, serverUrl) || other.serverUrl == serverUrl)&&(identical(other.token, token) || other.token == token)&&(identical(other.teamId, teamId) || other.teamId == teamId)&&(identical(other.authType, authType) || other.authType == authType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,serverUrl,token,teamId,authType);
+
+@override
+String toString() {
+  return 'AuthProfile(serverUrl: $serverUrl, token: $token, teamId: $teamId, authType: $authType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AuthProfileCopyWith<$Res> implements $AuthProfileCopyWith<$Res> {
+  factory _$AuthProfileCopyWith(_AuthProfile value, $Res Function(_AuthProfile) _then) = __$AuthProfileCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'server_url') String serverUrl, String token,@JsonKey(name: 'team_id') String teamId,@JsonKey(name: 'auth_type') String authType
+});
+
+
+
+
+}
+/// @nodoc
+class __$AuthProfileCopyWithImpl<$Res>
+    implements _$AuthProfileCopyWith<$Res> {
+  __$AuthProfileCopyWithImpl(this._self, this._then);
+
+  final _AuthProfile _self;
+  final $Res Function(_AuthProfile) _then;
+
+/// Create a copy of AuthProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? serverUrl = null,Object? token = null,Object? teamId = null,Object? authType = null,}) {
+  return _then(_AuthProfile(
+serverUrl: null == serverUrl ? _self.serverUrl : serverUrl // ignore: cast_nullable_to_non_nullable
+as String,token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
+as String,teamId: null == teamId ? _self.teamId : teamId // ignore: cast_nullable_to_non_nullable
+as String,authType: null == authType ? _self.authType : authType // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CredentialConfig {
+
+@JsonKey(name: 'active_profile') String get activeProfile; Map<String, AuthProfile> get profiles;
+/// Create a copy of CredentialConfig
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CredentialConfigCopyWith<CredentialConfig> get copyWith => _$CredentialConfigCopyWithImpl<CredentialConfig>(this as CredentialConfig, _$identity);
+
+  /// Serializes this CredentialConfig to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CredentialConfig&&(identical(other.activeProfile, activeProfile) || other.activeProfile == activeProfile)&&const DeepCollectionEquality().equals(other.profiles, profiles));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,activeProfile,const DeepCollectionEquality().hash(profiles));
+
+@override
+String toString() {
+  return 'CredentialConfig(activeProfile: $activeProfile, profiles: $profiles)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CredentialConfigCopyWith<$Res>  {
+  factory $CredentialConfigCopyWith(CredentialConfig value, $Res Function(CredentialConfig) _then) = _$CredentialConfigCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'active_profile') String activeProfile, Map<String, AuthProfile> profiles
+});
+
+
+
+
+}
+/// @nodoc
+class _$CredentialConfigCopyWithImpl<$Res>
+    implements $CredentialConfigCopyWith<$Res> {
+  _$CredentialConfigCopyWithImpl(this._self, this._then);
+
+  final CredentialConfig _self;
+  final $Res Function(CredentialConfig) _then;
+
+/// Create a copy of CredentialConfig
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? activeProfile = null,Object? profiles = null,}) {
+  return _then(_self.copyWith(
+activeProfile: null == activeProfile ? _self.activeProfile : activeProfile // ignore: cast_nullable_to_non_nullable
+as String,profiles: null == profiles ? _self.profiles : profiles // ignore: cast_nullable_to_non_nullable
+as Map<String, AuthProfile>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [CredentialConfig].
+extension CredentialConfigPatterns on CredentialConfig {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _CredentialConfig value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _CredentialConfig() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _CredentialConfig value)  $default,){
+final _that = this;
+switch (_that) {
+case _CredentialConfig():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _CredentialConfig value)?  $default,){
+final _that = this;
+switch (_that) {
+case _CredentialConfig() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'active_profile')  String activeProfile,  Map<String, AuthProfile> profiles)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _CredentialConfig() when $default != null:
+return $default(_that.activeProfile,_that.profiles);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'active_profile')  String activeProfile,  Map<String, AuthProfile> profiles)  $default,) {final _that = this;
+switch (_that) {
+case _CredentialConfig():
+return $default(_that.activeProfile,_that.profiles);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'active_profile')  String activeProfile,  Map<String, AuthProfile> profiles)?  $default,) {final _that = this;
+switch (_that) {
+case _CredentialConfig() when $default != null:
+return $default(_that.activeProfile,_that.profiles);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _CredentialConfig implements CredentialConfig {
+  const _CredentialConfig({@JsonKey(name: 'active_profile') this.activeProfile = 'default', final  Map<String, AuthProfile> profiles = const {}}): _profiles = profiles;
+  factory _CredentialConfig.fromJson(Map<String, dynamic> json) => _$CredentialConfigFromJson(json);
+
+@override@JsonKey(name: 'active_profile') final  String activeProfile;
+ final  Map<String, AuthProfile> _profiles;
+@override@JsonKey() Map<String, AuthProfile> get profiles {
+  if (_profiles is EqualUnmodifiableMapView) return _profiles;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_profiles);
+}
+
+
+/// Create a copy of CredentialConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CredentialConfigCopyWith<_CredentialConfig> get copyWith => __$CredentialConfigCopyWithImpl<_CredentialConfig>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CredentialConfigToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CredentialConfig&&(identical(other.activeProfile, activeProfile) || other.activeProfile == activeProfile)&&const DeepCollectionEquality().equals(other._profiles, _profiles));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,activeProfile,const DeepCollectionEquality().hash(_profiles));
+
+@override
+String toString() {
+  return 'CredentialConfig(activeProfile: $activeProfile, profiles: $profiles)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CredentialConfigCopyWith<$Res> implements $CredentialConfigCopyWith<$Res> {
+  factory _$CredentialConfigCopyWith(_CredentialConfig value, $Res Function(_CredentialConfig) _then) = __$CredentialConfigCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'active_profile') String activeProfile, Map<String, AuthProfile> profiles
+});
+
+
+
+
+}
+/// @nodoc
+class __$CredentialConfigCopyWithImpl<$Res>
+    implements _$CredentialConfigCopyWith<$Res> {
+  __$CredentialConfigCopyWithImpl(this._self, this._then);
+
+  final _CredentialConfig _self;
+  final $Res Function(_CredentialConfig) _then;
+
+/// Create a copy of CredentialConfig
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? activeProfile = null,Object? profiles = null,}) {
+  return _then(_CredentialConfig(
+activeProfile: null == activeProfile ? _self.activeProfile : activeProfile // ignore: cast_nullable_to_non_nullable
+as String,profiles: null == profiles ? _self._profiles : profiles // ignore: cast_nullable_to_non_nullable
+as Map<String, AuthProfile>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/apps/genuineci_cli/lib/src/auth/credential_store.g.dart
+++ b/apps/genuineci_cli/lib/src/auth/credential_store.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'credential_store.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AuthProfile _$AuthProfileFromJson(Map<String, dynamic> json) => _AuthProfile(
+  serverUrl: json['server_url'] as String? ?? 'http://localhost:8080',
+  token: json['token'] as String? ?? '',
+  teamId: json['team_id'] as String? ?? '',
+  authType: json['auth_type'] as String? ?? 'api_key',
+);
+
+Map<String, dynamic> _$AuthProfileToJson(_AuthProfile instance) =>
+    <String, dynamic>{
+      'server_url': instance.serverUrl,
+      'token': instance.token,
+      'team_id': instance.teamId,
+      'auth_type': instance.authType,
+    };
+
+_CredentialConfig _$CredentialConfigFromJson(Map<String, dynamic> json) =>
+    _CredentialConfig(
+      activeProfile: json['active_profile'] as String? ?? 'default',
+      profiles:
+          (json['profiles'] as Map<String, dynamic>?)?.map(
+            (k, e) =>
+                MapEntry(k, AuthProfile.fromJson(e as Map<String, dynamic>)),
+          ) ??
+          const {},
+    );
+
+Map<String, dynamic> _$CredentialConfigToJson(_CredentialConfig instance) =>
+    <String, dynamic>{
+      'active_profile': instance.activeProfile,
+      'profiles': instance.profiles,
+    };

--- a/apps/genuineci_cli/pubspec.yaml
+++ b/apps/genuineci_cli/pubspec.yaml
@@ -11,12 +11,16 @@ resolution: workspace
 # Add regular dependencies here.
 dependencies:
   args: ^2.7.0
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
   mason_logger: ^0.3.4
   path: ^1.9.0
   slang: ^4.19.0
 
 dev_dependencies:
   build_runner: ^2.16.0
+  freezed: ^3.2.5
+  json_serializable: ^6.14.1
   lints: ^6.0.0
   slang_build_runner: ^4.19.0
   test: ^1.25.6

--- a/apps/genuineci_cli/test/credential_store_test.dart
+++ b/apps/genuineci_cli/test/credential_store_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:genuineci_cli/genuineci_cli.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+  late String customConfigPath;
+  late CredentialStore store;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('genuineci_cred_test_');
+    customConfigPath = p.join(tempDir.path, 'credentials.json');
+    store = CredentialStore(customFilePath: customConfigPath);
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test(
+    'load returns empty config when credentials file does not exist',
+    () async {
+      final config = await store.load();
+      expect(config.activeProfile, equals('default'));
+      expect(config.profiles, isEmpty);
+      expect(await store.getActiveProfile(), isNull);
+    },
+  );
+
+  test(
+    'saveProfile persists profile and sets it as active by default',
+    () async {
+      const localProfile = AuthProfile(
+        serverUrl: 'http://localhost:8080',
+        token: 'test-internal-key',
+        teamId: 'dev-team',
+        authType: 'api_key',
+      );
+
+      await store.saveProfile('local', localProfile);
+
+      final loaded = await store.load();
+      expect(loaded.activeProfile, equals('local'));
+      expect(loaded.profiles['local'], equals(localProfile));
+
+      final active = await store.getActiveProfile();
+      expect(active, equals(localProfile));
+    },
+  );
+
+  test('saveProfile supports multiple profiles and active switching', () async {
+    const localProfile = AuthProfile(
+      serverUrl: 'http://localhost:8080',
+      token: 'local-key',
+      teamId: 'local-team',
+    );
+    const prodProfile = AuthProfile(
+      serverUrl: 'https://api.openci.org',
+      token: 'prod-token',
+      teamId: 'prod-team',
+      authType: 'firebase_token',
+    );
+
+    await store.saveProfile('local', localProfile, setActive: true);
+    await store.saveProfile('default', prodProfile, setActive: false);
+
+    final active = await store.getActiveProfile();
+    expect(active, equals(localProfile));
+
+    final prod = await store.getProfile('default');
+    expect(prod, equals(prodProfile));
+  });
+
+  test(
+    'deleteProfile removes profile and updates active profile if needed',
+    () async {
+      const localProfile = AuthProfile(
+        serverUrl: 'http://localhost:8080',
+        token: 'key',
+        teamId: 'team',
+      );
+
+      await store.saveProfile('local', localProfile);
+      expect(await store.getProfile('local'), isNotNull);
+
+      final deleted = await store.deleteProfile('local');
+      expect(deleted, isTrue);
+      expect(await store.getProfile('local'), isNull);
+      expect(await store.getActiveProfile(), isNull);
+
+      final deleteNonExistent = await store.deleteProfile('non-existent');
+      expect(deleteNonExistent, isFalse);
+    },
+  );
+}

--- a/apps/genuineci_cli/test/credential_store_test.dart
+++ b/apps/genuineci_cli/test/credential_store_test.dart
@@ -96,4 +96,30 @@ void main() {
       expect(deleteNonExistent, isFalse);
     },
   );
+
+  test('toString masks token in AuthProfile and CredentialConfig', () {
+    const profile = AuthProfile(
+      serverUrl: 'http://localhost:8080',
+      token: 'super-secret-api-key-12345',
+      teamId: 'team-alpha',
+      authType: 'api_key',
+    );
+
+    final profileStr = profile.toString();
+    expect(profileStr, contains('http://localhost:8080'));
+    expect(profileStr, contains('team-alpha'));
+    expect(profileStr, contains('api_key'));
+    expect(profileStr, contains('token: ***'));
+    expect(profileStr, isNot(contains('super-secret-api-key-12345')));
+
+    const config = CredentialConfig(
+      activeProfile: 'local',
+      profiles: {'local': profile},
+    );
+
+    final configStr = config.toString();
+    expect(configStr, contains('activeProfile: local'));
+    expect(configStr, contains('token: ***'));
+    expect(configStr, isNot(contains('super-secret-api-key-12345')));
+  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,18 +873,18 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.0"
   json_serializable:
     dependency: transitive
     description:
       name: json_serializable
-      sha256: "44729f5c45748e6748f6b9a57ab8f7e4336edc8ae41fc295070e3814e616a6c0"
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.13.0"
+    version: "6.14.1"
   leak_tracker:
     dependency: transitive
     description:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 認証情報を保存・読み込みできるようになりました。
  - 複数の認証プロファイルを保存し、取得・切り替え・削除できます。
  - 認証設定をJSON形式で管理し、指定した保存先にも対応しました。
  - 認証情報関連の機能を外部から利用できるようになりました。
- **改善**
  - 認証情報の保存中に問題が発生した場合でも、設定ファイルが破損しにくくなりました。
  - ログ出力時に認証トークンがマスクされるようになりました。
  - 不正な認証設定を適切に検出できるようになりました。
- **翻訳**
  - 言語設定の説明、成功メッセージ、無効な言語のエラーメッセージを英語・日本語に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->