### PR TITLE
feat(config): update default config file path to use applicationConfigHome from `cli_util`

### DIFF
--- a/apps/genuineci_cli/lib/src/config/cli_config.dart
+++ b/apps/genuineci_cli/lib/src/config/cli_config.dart
@@ -1,20 +1,19 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:cli_util/cli_util.dart';
 import 'package:path/path.dart' as p;
 
 class CliConfig {
   final String _filePath;
 
   CliConfig({String? customFilePath})
-    : _filePath = customFilePath ?? _defaultConfigPath();
+    : _filePath = customFilePath ?? _defaultConfigFilePath();
 
-  static String _defaultConfigPath() {
-    final home =
-        Platform.environment['HOME'] ??
-        Platform.environment['USERPROFILE'] ??
-        Directory.current.path;
-    return p.join(home, '.genuineci', 'config.json');
+  static String _defaultConfigFilePath() {
+    final homeDir = applicationConfigHome('genuineci');
+    final configFilePath = p.join(homeDir, 'config.json');
+    return configFilePath;
   }
 
   Map<String, dynamic> _readSync() {

--- a/apps/genuineci_cli/lib/src/config/cli_config.dart
+++ b/apps/genuineci_cli/lib/src/config/cli_config.dart
@@ -11,8 +11,11 @@ class CliConfig {
     : _filePath = customFilePath ?? _defaultConfigFilePath();
 
   static String _defaultConfigFilePath() {
-    final homeDir = applicationConfigHome('genuineci');
-    final configFilePath = p.join(homeDir, 'config.json');
+    const productName = 'genuineci';
+    const configFileName = 'config.json';
+
+    final homeDir = applicationConfigHome(productName);
+    final configFilePath = p.join(homeDir, configFileName);
     return configFilePath;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - CLIの設定ファイルに使用する既定の保存場所を標準化しました。
  - 環境変数や実行時のカレントディレクトリに左右されず、安定した場所から設定を読み込めるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->