### PR TITLE
refactor(i18n): update initI18n and language methods to use async/await

### DIFF
--- a/apps/genuineci_cli/bin/genuineci_cli.dart
+++ b/apps/genuineci_cli/bin/genuineci_cli.dart
@@ -4,7 +4,7 @@ import 'package:args/command_runner.dart';
 import 'package:genuineci_cli/genuineci_cli.dart';
 
 Future<void> main(List<String> arguments) async {
-  initI18n();
+  await initI18n();
 
   final runner = GenuineCiCommandRunner();
   try {

--- a/apps/genuineci_cli/lib/src/commands/use_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/use_command.dart
@@ -43,7 +43,7 @@ class UseCommand extends Command<int> {
         return 1;
     }
 
-    _languageConfig.setLanguage(targetCode);
+    await _languageConfig.setLanguage(targetCode);
 
     _logger.stdout(t.use.success(language: languageName));
     return 0;

--- a/apps/genuineci_cli/lib/src/config/cli_config.dart
+++ b/apps/genuineci_cli/lib/src/config/cli_config.dart
@@ -20,13 +20,13 @@ class CliConfig {
     return configFilePath;
   }
 
-  Map<String, dynamic> read() {
+  Future<Map<String, dynamic>> read() async {
     final file = File(_configFilePath);
-    if (!file.existsSync()) {
+    if (!await file.exists()) {
       return {};
     }
 
-    final content = file.readAsStringSync();
+    final content = await file.readAsString();
     if (content.trim().isEmpty) {
       throw FormatException('Config file at $_configFilePath is empty.');
     }
@@ -40,12 +40,12 @@ class CliConfig {
     return json;
   }
 
-  void write(Map<String, dynamic> data) {
+  Future<void> write(Map<String, dynamic> data) async {
     final file = File(_configFilePath);
     final dir = file.parent;
-    if (!dir.existsSync()) {
-      dir.createSync(recursive: true);
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
     }
-    file.writeAsStringSync(jsonEncode(data));
+    await file.writeAsString(jsonEncode(data));
   }
 }

--- a/apps/genuineci_cli/lib/src/i18n/i18n.dart
+++ b/apps/genuineci_cli/lib/src/i18n/i18n.dart
@@ -3,9 +3,9 @@ import '../gen/strings.g.dart';
 
 export '../gen/strings.g.dart';
 
-void initI18n({EditLanguageConfig? languageConfig}) {
+Future<void> initI18n({EditLanguageConfig? languageConfig}) async {
   final langConfig = languageConfig ?? EditLanguageConfig();
-  final configuredLang = langConfig.getLanguage();
+  final configuredLang = await langConfig.getLanguage();
 
   if (configuredLang == 'ja') {
     LocaleSettings.setLocaleSync(AppLocale.ja);
@@ -19,15 +19,15 @@ class EditLanguageConfig {
 
   EditLanguageConfig({CliConfig? config}) : _config = config ?? CliConfig();
 
-  String? getLanguage() {
-    final data = _config.read();
+  Future<String?> getLanguage() async {
+    final data = await _config.read();
     return data['language'] as String?;
   }
 
-  void setLanguage(String languageCode) {
-    final data = _config.read();
+  Future<void> setLanguage(String languageCode) async {
+    final data = await _config.read();
     data['language'] = languageCode;
-    _config.write(data);
+    await _config.write(data);
 
     final locale = AppLocaleUtils.parse(languageCode);
     LocaleSettings.setLocaleSync(locale);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - CLI起動時に言語設定の読み込み完了を待機するようになり、初期表示が正しい言語で安定するようになりました。
  - 言語変更後、設定の保存完了を確認してから成功メッセージを表示するようになりました。
  - CLI設定の読み書きが非同期処理に対応し、設定ファイル操作の信頼性が向上しました。
  - 空の設定ファイルや不正なJSONに対する検証とエラー処理を維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->