### PR TITLE
refactor(CliConfig): rename read method to get for clarity

### DIFF
--- a/apps/genuineci_cli/lib/src/config/cli_config.dart
+++ b/apps/genuineci_cli/lib/src/config/cli_config.dart
@@ -24,7 +24,7 @@ class CliConfig {
     return configFilePath;
   }
 
-  Future<CliConfigData> read() async {
+  Future<CliConfigData> get() async {
     final file = File(_configFilePath);
     if (!await file.exists()) {
       return const CliConfigData();

--- a/apps/genuineci_cli/lib/src/i18n/i18n.dart
+++ b/apps/genuineci_cli/lib/src/i18n/i18n.dart
@@ -20,12 +20,12 @@ class EditLanguageConfig {
   EditLanguageConfig({CliConfig? config}) : _config = config ?? CliConfig();
 
   Future<String?> getLanguage() async {
-    final data = await _config.read();
+    final data = await _config.get();
     return data.language;
   }
 
   Future<void> setLanguage(String languageCode) async {
-    final current = await _config.read();
+    final current = await _config.get();
     final updated = current.copyWith(language: languageCode);
     await _config.write(updated);
 

--- a/apps/genuineci_cli/test/cli_config_test.dart
+++ b/apps/genuineci_cli/test/cli_config_test.dart
@@ -25,7 +25,7 @@ void main() {
     test(
       'read returns empty CliConfigData when config file does not exist',
       () async {
-        final data = await config.read();
+        final data = await config.get();
         expect(data, equals(const CliConfigData()));
         expect(data.language, isNull);
       },
@@ -35,7 +35,7 @@ void main() {
       const input = CliConfigData(language: 'ja');
       await config.write(input);
 
-      final data = await config.read();
+      final data = await config.get();
       expect(data, equals(input));
       expect(data.language, equals('ja'));
     });
@@ -54,7 +54,7 @@ void main() {
         await nestedConfig.write(const CliConfigData(language: 'en'));
 
         expect(await File(nestedPath).exists(), isTrue);
-        final data = await nestedConfig.read();
+        final data = await nestedConfig.get();
         expect(data, equals(const CliConfigData(language: 'en')));
       },
     );
@@ -63,7 +63,7 @@ void main() {
       await config.write(const CliConfigData(language: 'en'));
       await config.write(const CliConfigData(language: 'ja'));
 
-      final data = await config.read();
+      final data = await config.get();
       expect(data, equals(const CliConfigData(language: 'ja')));
     });
 
@@ -71,21 +71,21 @@ void main() {
       final file = File(customConfigPath);
       await file.writeAsString('   \n');
 
-      expect(() => config.read(), throwsA(isA<FormatException>()));
+      expect(() => config.get(), throwsA(isA<FormatException>()));
     });
 
     test('read throws FormatException when JSON is malformed', () async {
       final file = File(customConfigPath);
       await file.writeAsString('{ invalid json }');
 
-      expect(() => config.read(), throwsA(isA<FormatException>()));
+      expect(() => config.get(), throwsA(isA<FormatException>()));
     });
 
     test('read throws FormatException when root JSON is not a Map', () async {
       final file = File(customConfigPath);
       await file.writeAsString('["item1", "item2"]');
 
-      expect(() => config.read(), throwsA(isA<FormatException>()));
+      expect(() => config.get(), throwsA(isA<FormatException>()));
     });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - CLI設定を取得する公開メソッド名を、より分かりやすい名称に変更しました。
  - 設定の読み込みや言語設定の動作に変更はありません。

- **テスト**
  - 設定ファイルの新規作成、上書き、空ファイル、不正なJSONなど、各種ケースの検証を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->