### PR TITLE
feat(JsonFileStore): add chmod600 option for secure file writing

### DIFF
--- a/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
+++ b/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
@@ -39,6 +39,7 @@ extension AtomicFileExtension on File {
           );
         }
       }
+      await tempFile.writeAsString(content, flush: true);
       await tempFile.rename(path);
       if (chmod600 && !Platform.isWindows) {
         await Process.run('chmod', ['600', path]);

--- a/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
+++ b/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
@@ -2,7 +2,10 @@ import 'dart:io';
 import 'dart:math';
 
 extension AtomicFileExtension on File {
-  Future<void> writeAsStringAtomic(String content) async {
+  Future<void> writeAsStringAtomic(
+    String content, {
+    bool chmod600 = false,
+  }) async {
     final dir = parent;
     if (!await dir.exists()) {
       await dir.create(recursive: true);
@@ -24,7 +27,13 @@ extension AtomicFileExtension on File {
 
     try {
       await tempFile.writeAsString(content, flush: true);
+      if (chmod600 && !Platform.isWindows) {
+        await Process.run('chmod', ['600', tempFile.path]);
+      }
       await tempFile.rename(path);
+      if (chmod600 && !Platform.isWindows) {
+        await Process.run('chmod', ['600', path]);
+      }
     } catch (_) {
       if (await tempFile.exists()) {
         try {

--- a/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
+++ b/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
@@ -29,10 +29,28 @@ extension AtomicFileExtension on File {
       await tempFile.writeAsString(content, flush: true);
       if (chmod600 && !Platform.isWindows) {
         await Process.run('chmod', ['600', tempFile.path]);
+        final result = await Process.run('chmod', ['600', tempFile.path]);
+        if (result.exitCode != 0) {
+          throw ProcessException(
+            'chmod',
+            ['600', tempFile.path],
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
       }
       await tempFile.rename(path);
       if (chmod600 && !Platform.isWindows) {
         await Process.run('chmod', ['600', path]);
+        final result = await Process.run('chmod', ['600', path]);
+        if (result.exitCode != 0) {
+          throw ProcessException(
+            'chmod',
+            ['600', path],
+            result.stderr.toString(),
+            result.exitCode,
+          );
+        }
       }
     } catch (_) {
       if (await tempFile.exists()) {

--- a/apps/genuineci_cli/lib/src/json_file_store/json_file_store.dart
+++ b/apps/genuineci_cli/lib/src/json_file_store/json_file_store.dart
@@ -44,9 +44,11 @@ class JsonFileStore<T> {
     return fromJson(json);
   }
 
-  /// Serializes [data] and writes it atomically to the JSON file.
-  Future<void> set(T data) async {
+  Future<void> set(T data, {bool chmod600 = false}) async {
     final file = File(filePath);
-    await file.writeAsStringAtomic(jsonEncode(toJson(data)));
+    await file.writeAsStringAtomic(
+      jsonEncode(toJson(data)),
+      chmod600: chmod600,
+    );
   }
 }

--- a/apps/genuineci_cli/test/src/extensions/file_extensions_test.dart
+++ b/apps/genuineci_cli/test/src/extensions/file_extensions_test.dart
@@ -41,5 +41,21 @@ void main() {
 
       expect(await file.readAsString(), equals('updated'));
     });
+
+    test(
+      'writeAsStringAtomic sets permissions to 0600 when chmod600 is true',
+      () async {
+        final file = File(p.join(tempDir.path, 'secret.txt'));
+        await file.writeAsStringAtomic('secret content', chmod600: true);
+
+        expect(await file.exists(), isTrue);
+        expect(await file.readAsString(), equals('secret content'));
+
+        if (!Platform.isWindows) {
+          final stat = await file.stat();
+          expect(stat.modeString(), contains('rw-------'));
+        }
+      },
+    );
   });
 }

--- a/apps/genuineci_cli/test/src/extensions/file_extensions_test.dart
+++ b/apps/genuineci_cli/test/src/extensions/file_extensions_test.dart
@@ -53,7 +53,7 @@ void main() {
 
         if (!Platform.isWindows) {
           final stat = await file.stat();
-          expect(stat.modeString(), contains('rw-------'));
+          expect(stat.mode & 0x1ff, equals(0x180));
         }
       },
     );

--- a/apps/genuineci_cli/test/src/json_file_store/json_file_store_test.dart
+++ b/apps/genuineci_cli/test/src/json_file_store/json_file_store_test.dart
@@ -101,6 +101,19 @@ void main() {
       final data = await store.get();
       expect(data, equals((name: 'second', count: 2)));
     });
+
+    test('sets file permissions to 0600 when chmod600 is true', () async {
+      const sample = (name: 'secret', count: 99);
+      await store.set(sample, chmod600: true);
+
+      final data = await store.get();
+      expect(data, equals(sample));
+
+      if (!Platform.isWindows) {
+        final stat = await File(filePath).stat();
+        expect(stat.modeString(), contains('rw-------'));
+      }
+    });
   });
 
   group('JsonFileStore defaultPath', () {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ファイルおよびJSONデータのアトミック書き込み時に、権限を`0600`（所有者のみ読み書き可能）へ制限できるオプションを追加しました。
  - オプションを指定しない場合は、従来どおりの動作です。
  - Windows以外の環境で利用できます。

- **テスト**
  - ファイル権限が正しく設定されること、および書き込み内容が保持されることを確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->