### PR TITLE
fix(AtomicFileExtension): remove redundant chmod calls in writeAsStringAtomic method

### DIFF
--- a/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
+++ b/apps/genuineci_cli/lib/src/extensions/file_extensions.dart
@@ -28,7 +28,6 @@ extension AtomicFileExtension on File {
     try {
       await tempFile.writeAsString(content, flush: true);
       if (chmod600 && !Platform.isWindows) {
-        await Process.run('chmod', ['600', tempFile.path]);
         final result = await Process.run('chmod', ['600', tempFile.path]);
         if (result.exitCode != 0) {
           throw ProcessException(
@@ -42,7 +41,6 @@ extension AtomicFileExtension on File {
       await tempFile.writeAsString(content, flush: true);
       await tempFile.rename(path);
       if (chmod600 && !Platform.isWindows) {
-        await Process.run('chmod', ['600', path]);
         final result = await Process.run('chmod', ['600', path]);
         if (result.exitCode != 0) {
           throw ProcessException(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - ファイルの権限変更に失敗した場合、処理が成功したものとして続行されず、適切にエラーを通知するようになりました。
  - 一時ファイルと最終ファイルの両方で、権限変更結果が正しく検証されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->