### PR TITLE
add find project root for dev command

### DIFF
--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -30,7 +30,8 @@
       "starting": "Starting OpenCI Local Development Environment...",
       "stepTart": "Step 1: Checking Tart VM base image...",
       "stepTartNotFound": "Error: Tart VM image \"base-macos\" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
-      "stepTartExists": "Tart VM (base-macos) exists."
+      "stepTartExists": "Tart VM (base-macos) exists.",
+      "projectRootNotFound": "Error: OpenCI project root not found."
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -30,7 +30,8 @@
       "starting": "OpenCI ローカル開発環境を起動しています...",
       "stepTart": "Step 1: Tart VM ベースイメージを確認中...",
       "stepTartNotFound": "エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
-      "stepTartExists": "Tart VM (base-macos) を確認しました。"
+      "stepTartExists": "Tart VM (base-macos) を確認しました。",
+      "projectRootNotFound": "エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。"
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -3,6 +3,7 @@ import 'package:cli_util/cli_logging.dart';
 
 import '../../i18n/i18n.dart';
 import 'check_tart_base_image.dart';
+import 'find_project_root.dart';
 
 class DevStartCommand extends Command<int> {
   @override
@@ -23,6 +24,13 @@ class DevStartCommand extends Command<int> {
     if (!hasTartImage) {
       return 1;
     }
+
+    final projectRoot = findProjectRoot();
+    if (projectRoot == null) {
+      _logger.stderr(t.dev.start.projectRootNotFound);
+      return 1;
+    }
+
     return 0;
   }
 }

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -20,14 +20,14 @@ class DevStartCommand extends Command<int> {
   Future<int> run() async {
     _logger.stdout(t.dev.start.starting);
 
-    final hasTartImage = await checkTartBaseImage(_logger);
-    if (!hasTartImage) {
-      return 1;
-    }
-
     final projectRoot = findProjectRoot();
     if (projectRoot == null) {
       _logger.stderr(t.dev.start.projectRootNotFound);
+      return 1;
+    }
+
+    final hasTartImage = await checkTartBaseImage(_logger);
+    if (!hasTartImage) {
       return 1;
     }
 

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 42 (21 per locale)
+/// Strings: 44 (22 per locale)
 ///
-/// Built on 2026-09-01 at 07:21 UTC
+/// Built on 2026-09-01 at 08:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -180,6 +180,9 @@ class Translations$dev$start$en {
 
 	/// en: 'Tart VM (base-macos) exists.'
 	String get stepTartExists => 'Tart VM (base-macos) exists.';
+
+	/// en: 'Error: OpenCI project root not found.'
+	String get projectRootNotFound => 'Error: OpenCI project root not found.';
 }
 
 /// The flat map containing all translations for locale <en>.
@@ -210,6 +213,7 @@ extension on Translations {
 			'dev.start.stepTart' => 'Step 1: Checking Tart VM base image...',
 			'dev.start.stepTartNotFound' => 'Error: Tart VM image "base-macos" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) exists.',
+			'dev.start.projectRootNotFound' => 'Error: OpenCI project root not found.',
 			'common.error' => ({required Object error}) => 'Error: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -139,6 +139,7 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepTart => 'Step 1: Tart VM ベースイメージを確認中...';
 	@override String get stepTartNotFound => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos';
 	@override String get stepTartExists => 'Tart VM (base-macos) を確認しました。';
+	@override String get projectRootNotFound => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。';
 }
 
 /// The flat map containing all translations for locale <ja>.
@@ -169,6 +170,7 @@ extension on TranslationsJa {
 			'dev.start.stepTart' => 'Step 1: Tart VM ベースイメージを確認中...',
 			'dev.start.stepTartNotFound' => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) を確認しました。',
+			'dev.start.projectRootNotFound' => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。',
 			'common.error' => ({required Object error}) => 'エラー: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:genuineci_cli/src/commands/dev/dev_start_command.dart';
+import 'package:genuineci_cli/src/i18n/i18n.dart';
+import 'package:test/test.dart';
+
+class _RecordingLogger implements Logger {
+  final stdoutMessages = <String>[];
+  final stderrMessages = <String>[];
+
+  @override
+  void stdout(String message) => stdoutMessages.add(message);
+
+  @override
+  void stderr(String message) => stderrMessages.add(message);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory originalDirectory;
+  late Directory tempDirectory;
+
+  setUp(() async {
+    originalDirectory = Directory.current;
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'dev_start_command_test_',
+    );
+    Directory.current = tempDirectory;
+  });
+
+  tearDown(() async {
+    Directory.current = originalDirectory;
+    await tempDirectory.delete(recursive: true);
+  });
+
+  test('reports projectRootNotFound before checking Tart', () async {
+    final logger = _RecordingLogger();
+
+    final result = await DevStartCommand(logger: logger).run();
+
+    expect(result, equals(1));
+    expect(logger.stdoutMessages, equals([t.dev.start.starting]));
+    expect(logger.stderrMessages, equals([t.dev.start.projectRootNotFound]));
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * OpenCI プロジェクトのルートを検出できない場合、Tart VM の確認前に明確なエラーメッセージを表示して終了するようになりました。
  * 既存の Tart VM を確認した際のメッセージを追加しました。
  * エラーメッセージは英語と日本語に対応しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->