### PR TITLE
Docker compose up

### DIFF
--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -31,6 +31,9 @@
       "stepTart": "Step 1: Checking Tart VM base image...",
       "stepTartNotFound": "Error: Tart VM image \"base-macos\" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
       "stepTartExists": "Tart VM (base-macos) exists.",
+      "stepDockerCompose": "Step 2: Starting Docker containers (db, Orchard, server, build-job-dispatcher)...",
+      "stepDockerComposeFailed": "Error: Failed to start Docker containers.",
+      "stepDockerComposeStarted": "Docker containers started.",
       "projectRootNotFound": "Error: OpenCI project root not found."
     }
   },

--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -30,7 +30,8 @@
       "starting": "Starting OpenCI Local Development Environment...",
       "stepTart": "Step 1: Checking Tart VM base image...",
       "stepTartNotFound": "Error: Tart VM image \"base-macos\" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
-      "stepTartExists": "Tart VM (base-macos) exists."
+      "stepTartExists": "Tart VM (base-macos) exists.",
+      "projectRootNotFound": "Error: OpenCI project root not found."
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -30,7 +30,8 @@
       "starting": "OpenCI ローカル開発環境を起動しています...",
       "stepTart": "Step 1: Tart VM ベースイメージを確認中...",
       "stepTartNotFound": "エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
-      "stepTartExists": "Tart VM (base-macos) を確認しました。"
+      "stepTartExists": "Tart VM (base-macos) を確認しました。",
+      "projectRootNotFound": "エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。"
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -31,6 +31,9 @@
       "stepTart": "Step 1: Tart VM ベースイメージを確認中...",
       "stepTartNotFound": "エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
       "stepTartExists": "Tart VM (base-macos) を確認しました。",
+      "stepDockerCompose": "Step 2: Docker コンテナ（db、Orchard、server、build-job-dispatcher）を起動中...",
+      "stepDockerComposeFailed": "エラー: Docker コンテナの起動に失敗しました。",
+      "stepDockerComposeStarted": "Docker コンテナを起動しました。",
       "projectRootNotFound": "エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。"
     }
   },

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -3,6 +3,7 @@ import 'package:cli_util/cli_logging.dart';
 
 import '../../i18n/i18n.dart';
 import 'check_tart_base_image.dart';
+import 'find_project_root.dart';
 
 class DevStartCommand extends Command<int> {
   @override
@@ -23,6 +24,13 @@ class DevStartCommand extends Command<int> {
     if (!hasTartImage) {
       return 1;
     }
+
+    final projectRoot = findProjectRoot();
+    if (projectRoot == null) {
+      _logger.stderr(t.dev.start.projectRootNotFound);
+      return 1;
+    }
+
     return 0;
   }
 }

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -4,6 +4,7 @@ import 'package:cli_util/cli_logging.dart';
 import '../../i18n/i18n.dart';
 import 'check_tart_base_image.dart';
 import 'find_project_root.dart';
+import 'start_docker_compose.dart';
 
 class DevStartCommand extends Command<int> {
   @override
@@ -28,6 +29,14 @@ class DevStartCommand extends Command<int> {
 
     final hasTartImage = await checkTartBaseImage(_logger);
     if (!hasTartImage) {
+      return 1;
+    }
+
+    final didStartDockerCompose = await startDockerCompose(
+      _logger,
+      projectRoot,
+    );
+    if (!didStartDockerCompose) {
       return 1;
     }
 

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -20,14 +20,14 @@ class DevStartCommand extends Command<int> {
   Future<int> run() async {
     _logger.stdout(t.dev.start.starting);
 
-    final hasTartImage = await checkTartBaseImage(_logger);
-    if (!hasTartImage) {
-      return 1;
-    }
-
     final projectRoot = findProjectRoot();
     if (projectRoot == null) {
       _logger.stderr(t.dev.start.projectRootNotFound);
+      return 1;
+    }
+
+    final hasTartImage = await checkTartBaseImage(_logger);
+    if (!hasTartImage) {
       return 1;
     }
 

--- a/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:meta/meta.dart';
+
+import '../../i18n/i18n.dart';
+
+typedef DockerComposeProcessRunner =
+    Future<int> Function(
+      String executable,
+      List<String> arguments, {
+      required String workingDirectory,
+      required Map<String, String> environment,
+    });
+
+const _dockerComposeArguments = [
+  'compose',
+  'up',
+  '-d',
+  '--build',
+  'db',
+  'orchard-controller',
+  'server',
+  'build-job-dispatcher',
+];
+
+Future<bool> startDockerCompose(
+  Logger logger,
+  Directory projectRoot, {
+  @visibleForTesting
+  DockerComposeProcessRunner processRunner = _runDockerComposeProcess,
+  @visibleForTesting Map<String, String>? environment,
+}) async {
+  logger.stdout('\n${t.dev.start.stepDockerCompose}');
+
+  final parentEnvironment = environment ?? Platform.environment;
+  final composeEnvironment = {
+    ...parentEnvironment,
+    'BASE_VM_NAME': parentEnvironment['BASE_VM_NAME'] ?? 'base-macos',
+    'INTERNAL_API_KEY':
+        parentEnvironment['INTERNAL_API_KEY'] ?? 'genuineci-local-dev-key',
+    'ORCHARD_API_URL': 'https://orchard-controller:6120',
+  };
+
+  try {
+    final exitCode = await processRunner(
+      'docker',
+      _dockerComposeArguments,
+      workingDirectory: projectRoot.path,
+      environment: composeEnvironment,
+    );
+    if (exitCode != 0) {
+      logger.stderr(t.dev.start.stepDockerComposeFailed);
+      return false;
+    }
+  } on ProcessException catch (error) {
+    logger.stderr('${t.dev.start.stepDockerComposeFailed}\n${error.message}');
+    return false;
+  }
+
+  logger.stdout(t.dev.start.stepDockerComposeStarted);
+  return true;
+}
+
+Future<int> _runDockerComposeProcess(
+  String executable,
+  List<String> arguments, {
+  required String workingDirectory,
+  required Map<String, String> environment,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    includeParentEnvironment: false,
+    mode: ProcessStartMode.inheritStdio,
+  );
+  return process.exitCode;
+}

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 42 (21 per locale)
+/// Strings: 44 (22 per locale)
 ///
-/// Built on 2026-09-01 at 07:21 UTC
+/// Built on 2026-09-01 at 08:40 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 44 (22 per locale)
+/// Strings: 50 (25 per locale)
 ///
-/// Built on 2026-09-01 at 08:40 UTC
+/// Built on 2026-09-02 at 07:38 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -180,6 +180,9 @@ class Translations$dev$start$en {
 
 	/// en: 'Tart VM (base-macos) exists.'
 	String get stepTartExists => 'Tart VM (base-macos) exists.';
+
+	/// en: 'Error: OpenCI project root not found.'
+	String get projectRootNotFound => 'Error: OpenCI project root not found.';
 }
 
 /// The flat map containing all translations for locale <en>.
@@ -210,6 +213,7 @@ extension on Translations {
 			'dev.start.stepTart' => 'Step 1: Checking Tart VM base image...',
 			'dev.start.stepTartNotFound' => 'Error: Tart VM image "base-macos" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) exists.',
+			'dev.start.projectRootNotFound' => 'Error: OpenCI project root not found.',
 			'common.error' => ({required Object error}) => 'Error: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -181,6 +181,15 @@ class Translations$dev$start$en {
 	/// en: 'Tart VM (base-macos) exists.'
 	String get stepTartExists => 'Tart VM (base-macos) exists.';
 
+	/// en: 'Step 2: Starting Docker containers (db, Orchard, server, build-job-dispatcher)...'
+	String get stepDockerCompose => 'Step 2: Starting Docker containers (db, Orchard, server, build-job-dispatcher)...';
+
+	/// en: 'Error: Failed to start Docker containers.'
+	String get stepDockerComposeFailed => 'Error: Failed to start Docker containers.';
+
+	/// en: 'Docker containers started.'
+	String get stepDockerComposeStarted => 'Docker containers started.';
+
 	/// en: 'Error: OpenCI project root not found.'
 	String get projectRootNotFound => 'Error: OpenCI project root not found.';
 }
@@ -213,6 +222,9 @@ extension on Translations {
 			'dev.start.stepTart' => 'Step 1: Checking Tart VM base image...',
 			'dev.start.stepTartNotFound' => 'Error: Tart VM image "base-macos" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) exists.',
+			'dev.start.stepDockerCompose' => 'Step 2: Starting Docker containers (db, Orchard, server, build-job-dispatcher)...',
+			'dev.start.stepDockerComposeFailed' => 'Error: Failed to start Docker containers.',
+			'dev.start.stepDockerComposeStarted' => 'Docker containers started.',
 			'dev.start.projectRootNotFound' => 'Error: OpenCI project root not found.',
 			'common.error' => ({required Object error}) => 'Error: ${error}',
 			_ => null,

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -139,6 +139,9 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepTart => 'Step 1: Tart VM ベースイメージを確認中...';
 	@override String get stepTartNotFound => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos';
 	@override String get stepTartExists => 'Tart VM (base-macos) を確認しました。';
+	@override String get stepDockerCompose => 'Step 2: Docker コンテナ（db、Orchard、server、build-job-dispatcher）を起動中...';
+	@override String get stepDockerComposeFailed => 'エラー: Docker コンテナの起動に失敗しました。';
+	@override String get stepDockerComposeStarted => 'Docker コンテナを起動しました。';
 	@override String get projectRootNotFound => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。';
 }
 
@@ -170,6 +173,9 @@ extension on TranslationsJa {
 			'dev.start.stepTart' => 'Step 1: Tart VM ベースイメージを確認中...',
 			'dev.start.stepTartNotFound' => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) を確認しました。',
+			'dev.start.stepDockerCompose' => 'Step 2: Docker コンテナ（db、Orchard、server、build-job-dispatcher）を起動中...',
+			'dev.start.stepDockerComposeFailed' => 'エラー: Docker コンテナの起動に失敗しました。',
+			'dev.start.stepDockerComposeStarted' => 'Docker コンテナを起動しました。',
 			'dev.start.projectRootNotFound' => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。',
 			'common.error' => ({required Object error}) => 'エラー: ${error}',
 			_ => null,

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -139,6 +139,7 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepTart => 'Step 1: Tart VM ベースイメージを確認中...';
 	@override String get stepTartNotFound => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos';
 	@override String get stepTartExists => 'Tart VM (base-macos) を確認しました。';
+	@override String get projectRootNotFound => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。';
 }
 
 /// The flat map containing all translations for locale <ja>.
@@ -169,6 +170,7 @@ extension on TranslationsJa {
 			'dev.start.stepTart' => 'Step 1: Tart VM ベースイメージを確認中...',
 			'dev.start.stepTartNotFound' => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) を確認しました。',
+			'dev.start.projectRootNotFound' => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。',
 			'common.error' => ({required Object error}) => 'エラー: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:genuineci_cli/src/commands/dev/dev_start_command.dart';
+import 'package:genuineci_cli/src/i18n/i18n.dart';
+import 'package:test/test.dart';
+
+class _RecordingLogger implements Logger {
+  final stdoutMessages = <String>[];
+  final stderrMessages = <String>[];
+
+  @override
+  void stdout(String message) => stdoutMessages.add(message);
+
+  @override
+  void stderr(String message) => stderrMessages.add(message);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory originalDirectory;
+  late Directory tempDirectory;
+
+  setUp(() async {
+    originalDirectory = Directory.current;
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'dev_start_command_test_',
+    );
+    Directory.current = tempDirectory;
+  });
+
+  tearDown(() async {
+    Directory.current = originalDirectory;
+    await tempDirectory.delete(recursive: true);
+  });
+
+  test('reports projectRootNotFound before checking Tart', () async {
+    final logger = _RecordingLogger();
+
+    final result = await DevStartCommand(logger: logger).run();
+
+    expect(result, equals(1));
+    expect(logger.stdoutMessages, equals([t.dev.start.starting]));
+    expect(logger.stderrMessages, equals([t.dev.start.projectRootNotFound]));
+  });
+}

--- a/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:genuineci_cli/src/commands/dev/start_docker_compose.dart';
+import 'package:genuineci_cli/src/i18n/i18n.dart';
+import 'package:test/test.dart';
+
+class _RecordingLogger implements Logger {
+  final stdoutMessages = <String>[];
+  final stderrMessages = <String>[];
+
+  @override
+  void stdout(String message) => stdoutMessages.add(message);
+
+  @override
+  void stderr(String message) => stderrMessages.add(message);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('startDockerCompose', () {
+    late _RecordingLogger logger;
+    late Directory projectRoot;
+
+    setUp(() {
+      logger = _RecordingLogger();
+      projectRoot = Directory('/path/to/openci');
+    });
+
+    test('starts the core services from the project root', () async {
+      late String executable;
+      late List<String> arguments;
+      late String capturedWorkingDirectory;
+      late Map<String, String> capturedEnvironment;
+
+      final result = await startDockerCompose(
+        logger,
+        projectRoot,
+        environment: const {
+          'PATH': '/usr/local/bin',
+          'BASE_VM_NAME': 'custom-base',
+          'ORCHARD_API_URL': 'https://ignored.example.com',
+        },
+        processRunner:
+            (
+              processExecutable,
+              processArguments, {
+              required workingDirectory,
+              required environment,
+            }) async {
+              executable = processExecutable;
+              arguments = processArguments;
+              capturedWorkingDirectory = workingDirectory;
+              capturedEnvironment = environment;
+              return 0;
+            },
+      );
+
+      expect(result, isTrue);
+      expect(executable, equals('docker'));
+      expect(
+        arguments,
+        equals([
+          'compose',
+          'up',
+          '-d',
+          '--build',
+          'db',
+          'orchard-controller',
+          'server',
+          'build-job-dispatcher',
+        ]),
+      );
+      expect(capturedWorkingDirectory, equals(projectRoot.path));
+      expect(capturedEnvironment, {
+        'PATH': '/usr/local/bin',
+        'BASE_VM_NAME': 'custom-base',
+        'ORCHARD_API_URL': 'https://orchard-controller:6120',
+        'INTERNAL_API_KEY': 'genuineci-local-dev-key',
+      });
+      expect(logger.stderrMessages, isEmpty);
+      expect(
+        logger.stdoutMessages,
+        equals([
+          '\n${t.dev.start.stepDockerCompose}',
+          t.dev.start.stepDockerComposeStarted,
+        ]),
+      );
+    });
+
+    test('returns false when Docker Compose exits with an error', () async {
+      const dockerComposeFailureExitCode = 17;
+
+      final result = await startDockerCompose(
+        logger,
+        projectRoot,
+        environment: const {},
+        processRunner:
+            (_, _, {required workingDirectory, required environment}) async =>
+                dockerComposeFailureExitCode,
+      );
+
+      expect(result, isFalse);
+      expect(logger.stderrMessages, [t.dev.start.stepDockerComposeFailed]);
+      expect(logger.stdoutMessages, ['\n${t.dev.start.stepDockerCompose}']);
+    });
+
+    test('returns false when Docker cannot be started', () async {
+      final result = await startDockerCompose(
+        logger,
+        projectRoot,
+        environment: const {},
+        processRunner:
+            (
+              executable,
+              arguments, {
+              required workingDirectory,
+              required environment,
+            }) async {
+              throw ProcessException(executable, arguments, 'not found');
+            },
+      );
+
+      expect(result, isFalse);
+      expect(logger.stderrMessages, hasLength(1));
+      expect(
+        logger.stderrMessages.single,
+        contains(t.dev.start.stepDockerComposeFailed),
+      );
+      expect(logger.stderrMessages.single, contains('not found'));
+    });
+  });
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `dev.start` でDocker Composeサービスをビルド・バックグラウンド起動できるようになりました。
  * 起動状況、成功、失敗を英語・日本語で表示します。
  * 起動失敗時は適切なエラー結果を返します。

* **テスト**
  * Docker Composeの起動処理、環境変数の引き渡し、成功・失敗時の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->