### PR TITLE
refactor(check_tart_base_image): improve argument handling and update tests

### DIFF
--- a/apps/genuineci_cli/lib/src/commands/dev/check_tart_base_image.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/check_tart_base_image.dart
@@ -5,6 +5,9 @@ import 'package:meta/meta.dart';
 
 import '../../i18n/i18n.dart';
 
+const _baseImageName = 'base-macos';
+const _listLocalImagesArguments = ['list', '--source', 'local', '--quiet'];
+
 typedef ProcessRunner =
     Future<ProcessResult> Function(
       String executable,
@@ -17,11 +20,21 @@ Future<bool> checkTartBaseImage(
   @visibleForTesting ProcessRunner processRunner = Process.run,
 }) async {
   logger.stdout('\n${t.dev.start.stepTart}');
-  final tartListResult = await processRunner('tart', [
-    'list',
-  ], runInShell: true);
+
+  late final ProcessResult tartListResult;
+  try {
+    tartListResult = await processRunner(
+      'tart',
+      _listLocalImagesArguments,
+      runInShell: true,
+    );
+  } on ProcessException {
+    logger.stderr(t.dev.start.stepTartNotFound);
+    return false;
+  }
+
   if (tartListResult.exitCode != 0 ||
-      !hasExactVmName(tartListResult.stdout.toString(), 'base-macos')) {
+      !hasExactVmName(tartListResult.stdout.toString(), _baseImageName)) {
     logger.stderr(t.dev.start.stepTartNotFound);
     return false;
   }
@@ -31,14 +44,5 @@ Future<bool> checkTartBaseImage(
 
 @visibleForTesting
 bool hasExactVmName(String output, String targetName) {
-  final lines = output.split('\n');
-  for (final line in lines) {
-    final trimmed = line.trim();
-    if (trimmed.isEmpty) continue;
-    final parts = trimmed.split(RegExp(r'\s+'));
-    if (parts.isNotEmpty && parts.first == targetName) {
-      return true;
-    }
-  }
-  return false;
+  return output.split('\n').map((line) => line.trim()).contains(targetName);
 }

--- a/apps/genuineci_cli/test/src/commands/dev/check_tart_base_image_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/check_tart_base_image_test.dart
@@ -10,26 +10,15 @@ void main() {
       expect(hasExactVmName('base-macos', 'base-macos'), isTrue);
     });
 
-    test(
-      'returns true when exact VM name is listed among multiple columns and rows',
-      () {
-        const output = '''
-NAME            SOURCE                                          DISK    SIZE
-base-macos      ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5      50GB    15GB
-other-vm        ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
-''';
-        expect(hasExactVmName(output, 'base-macos'), isTrue);
-      },
-    );
+    test('returns true when exact VM name is listed among multiple rows', () {
+      const output = 'other-vm\nbase-macos\ndevelopment-vm\n';
+      expect(hasExactVmName(output, 'base-macos'), isTrue);
+    });
 
     test(
       'returns false when VM name is only a substring (e.g. base-macos-old)',
       () {
-        const output = '''
-NAME            SOURCE                                          DISK    SIZE
-base-macos-old  ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5      50GB    15GB
-my-base-macos   ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
-''';
+        const output = 'base-macos-old\nmy-base-macos\n';
         expect(hasExactVmName(output, 'base-macos'), isFalse);
       },
     );
@@ -49,17 +38,19 @@ my-base-macos   ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
     test(
       'returns true when tart list succeeds (exitCode 0) and contains base-macos',
       () async {
+        late String receivedExecutable;
+        late List<String> receivedArguments;
+        late bool receivedRunInShell;
+
         Future<ProcessResult> mockRunner(
           String executable,
           List<String> arguments, {
           bool runInShell = false,
         }) async {
-          return ProcessResult(
-            0,
-            0,
-            'base-macos   ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n',
-            '',
-          );
+          receivedExecutable = executable;
+          receivedArguments = arguments;
+          receivedRunInShell = runInShell;
+          return ProcessResult(0, 0, 'base-macos\n', '');
         }
 
         final result = await checkTartBaseImage(
@@ -67,6 +58,12 @@ my-base-macos   ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
           processRunner: mockRunner,
         );
         expect(result, isTrue);
+        expect(receivedExecutable, equals('tart'));
+        expect(
+          receivedArguments,
+          equals(['list', '--source', 'local', '--quiet']),
+        );
+        expect(receivedRunInShell, isTrue);
       },
     );
 
@@ -94,12 +91,7 @@ my-base-macos   ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
           List<String> arguments, {
           bool runInShell = false,
         }) async {
-          return ProcessResult(
-            0,
-            0,
-            'base-macos-old   ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n',
-            '',
-          );
+          return ProcessResult(0, 0, 'base-macos-old\n', '');
         }
 
         final result = await checkTartBaseImage(
@@ -109,5 +101,21 @@ my-base-macos   ghcr.io/cirruslabs/macos-runner:latest          50GB    20GB
         expect(result, isFalse);
       },
     );
+
+    test('returns false when tart is unavailable', () async {
+      Future<ProcessResult> mockRunner(
+        String executable,
+        List<String> arguments, {
+        bool runInShell = false,
+      }) async {
+        throw ProcessException(executable, arguments);
+      }
+
+      final result = await checkTartBaseImage(
+        logger,
+        processRunner: mockRunner,
+      );
+      expect(result, isFalse);
+    });
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Tart のローカルイメージ確認時、コマンド実行に失敗した場合でもエラーメッセージを表示し、適切に判定できるようになりました。
  * VM 名の判定を行全体の完全一致に変更し、部分一致による誤判定を防止しました。

* **テスト**
  * Tart の実行引数や実行結果、利用できない場合の動作に関するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->