### PR TITLE
feat(dev): add seed flag to start command for local test data seeding

### DIFF
--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -27,6 +27,9 @@
     "description": "Manage local development environment (Docker, Tart, DB, Server).",
     "start": {
       "description": "Start local development environment (Docker containers, Tart VM, Orchard).",
+      "flags": {
+        "seed": "Seed local test data after starting services."
+      },
       "starting": "Starting OpenCI Local Development Environment...",
       "stepTart": "Step 1: Checking Tart VM base image...",
       "stepTartNotFound": "Error: Tart VM image \"base-macos\" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -27,6 +27,9 @@
     "description": "ローカル開発環境（Docker, Tart, DB, サーバー）を管理します。",
     "start": {
       "description": "ローカル開発環境（Docker コンテナ、Tart VM、Orchard）を起動します。",
+      "flags": {
+        "seed": "サービス起動後にローカルテストデータを投入します。"
+      },
       "starting": "OpenCI ローカル開発環境を起動しています...",
       "stepTart": "Step 1: Tart VM ベースイメージを確認中...",
       "stepTartNotFound": "エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
+import 'package:meta/meta.dart';
 
 import '../../i18n/i18n.dart';
 import 'check_tart_base_image.dart';
@@ -7,6 +10,13 @@ import 'find_project_root.dart';
 import 'seed_local_data.dart';
 import 'setup_orchard_context.dart';
 import 'start_docker_compose.dart';
+
+typedef ProjectRootFinder = Directory? Function();
+typedef TartBaseImageChecker = Future<bool> Function(Logger logger);
+typedef DockerComposeStarter =
+    Future<bool> Function(Logger logger, Directory projectRoot);
+typedef OrchardContextSetup = Future<bool> Function(Logger logger);
+typedef LocalDataSeeder = Future<bool> Function(Logger logger);
 
 class DevStartCommand extends Command<int> {
   @override
@@ -16,8 +26,28 @@ class DevStartCommand extends Command<int> {
   String get description => t.dev.start.description;
 
   final Logger _logger;
+  final ProjectRootFinder _projectRootFinder;
+  final TartBaseImageChecker _tartBaseImageChecker;
+  final DockerComposeStarter _dockerComposeStarter;
+  final OrchardContextSetup _orchardContextSetup;
+  final LocalDataSeeder _localDataSeeder;
 
-  DevStartCommand({required Logger logger}) : _logger = logger {
+  DevStartCommand({
+    required Logger logger,
+    @visibleForTesting ProjectRootFinder projectRootFinder = findProjectRoot,
+    @visibleForTesting
+    TartBaseImageChecker tartBaseImageChecker = checkTartBaseImage,
+    @visibleForTesting
+    DockerComposeStarter dockerComposeStarter = startDockerCompose,
+    @visibleForTesting
+    OrchardContextSetup orchardContextSetup = setupOrchardContext,
+    @visibleForTesting LocalDataSeeder localDataSeeder = seedLocalData,
+  }) : _logger = logger,
+       _projectRootFinder = projectRootFinder,
+       _tartBaseImageChecker = tartBaseImageChecker,
+       _dockerComposeStarter = dockerComposeStarter,
+       _orchardContextSetup = orchardContextSetup,
+       _localDataSeeder = localDataSeeder {
     argParser.addFlag('seed', negatable: false, help: t.dev.start.flags.seed);
   }
 
@@ -25,18 +55,18 @@ class DevStartCommand extends Command<int> {
   Future<int> run() async {
     _logger.stdout(t.dev.start.starting);
 
-    final projectRoot = findProjectRoot();
+    final projectRoot = _projectRootFinder();
     if (projectRoot == null) {
       _logger.stderr(t.dev.start.projectRootNotFound);
       return 1;
     }
 
-    final hasTartImage = await checkTartBaseImage(_logger);
+    final hasTartImage = await _tartBaseImageChecker(_logger);
     if (!hasTartImage) {
       return 1;
     }
 
-    final didStartDockerCompose = await startDockerCompose(
+    final didStartDockerCompose = await _dockerComposeStarter(
       _logger,
       projectRoot,
     );
@@ -44,14 +74,14 @@ class DevStartCommand extends Command<int> {
       return 1;
     }
 
-    final didSetupOrchardContext = await setupOrchardContext(_logger);
+    final didSetupOrchardContext = await _orchardContextSetup(_logger);
     if (!didSetupOrchardContext) {
       return 1;
     }
 
     final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
     if (shouldSeedLocalData) {
-      final didSeedLocalData = await seedLocalData(_logger);
+      final didSeedLocalData = await _localDataSeeder(_logger);
       if (!didSeedLocalData) {
         return 1;
       }

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -17,7 +17,9 @@ class DevStartCommand extends Command<int> {
 
   final Logger _logger;
 
-  DevStartCommand({required Logger logger}) : _logger = logger;
+  DevStartCommand({required Logger logger}) : _logger = logger {
+    argParser.addFlag('seed', negatable: false, help: t.dev.start.flags.seed);
+  }
 
   @override
   Future<int> run() async {
@@ -47,9 +49,12 @@ class DevStartCommand extends Command<int> {
       return 1;
     }
 
-    final didSeedLocalData = await seedLocalData(_logger);
-    if (!didSeedLocalData) {
-      return 1;
+    final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
+    if (shouldSeedLocalData) {
+      final didSeedLocalData = await seedLocalData(_logger);
+      if (!didSeedLocalData) {
+        return 1;
+      }
     }
 
     return 0;

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -45,4 +45,12 @@ void main() {
     expect(logger.stdoutMessages, equals([t.dev.start.starting]));
     expect(logger.stderrMessages, equals([t.dev.start.projectRootNotFound]));
   });
+
+  test('seed flag is opt-in', () {
+    final command = DevStartCommand(logger: _RecordingLogger());
+
+    expect(command.argParser.parse([]).flag('seed'), isFalse);
+    expect(command.argParser.parse(['--seed']).flag('seed'), isTrue);
+    expect(command.argParser.usage, contains(t.dev.start.flags.seed));
+  });
 }

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:genuineci_cli/src/commands/dev/dev_start_command.dart';
 import 'package:genuineci_cli/src/i18n/i18n.dart';
@@ -36,6 +37,29 @@ void main() {
     await tempDirectory.delete(recursive: true);
   });
 
+  Future<int?> runStart({
+    required bool shouldSeed,
+    required bool seedSucceeds,
+    required void Function() onSeed,
+  }) {
+    final runner = CommandRunner<int>('genuineci', 'CLI tool')
+      ..addCommand(
+        DevStartCommand(
+          logger: _RecordingLogger(),
+          projectRootFinder: () => tempDirectory,
+          tartBaseImageChecker: (_) async => true,
+          dockerComposeStarter: (_, _) async => true,
+          orchardContextSetup: (_) async => true,
+          localDataSeeder: (_) async {
+            onSeed();
+            return seedSucceeds;
+          },
+        ),
+      );
+
+    return runner.run(['start', if (shouldSeed) '--seed']);
+  }
+
   test('reports projectRootNotFound before checking Tart', () async {
     final logger = _RecordingLogger();
 
@@ -52,5 +76,44 @@ void main() {
     expect(command.argParser.parse([]).flag('seed'), isFalse);
     expect(command.argParser.parse(['--seed']).flag('seed'), isTrue);
     expect(command.argParser.usage, contains(t.dev.start.flags.seed));
+  });
+
+  test('does not seed local data when --seed is omitted', () async {
+    var seedCallCount = 0;
+
+    final result = await runStart(
+      shouldSeed: false,
+      seedSucceeds: true,
+      onSeed: () => seedCallCount++,
+    );
+
+    expect(result, equals(0));
+    expect(seedCallCount, equals(0));
+  });
+
+  test('seeds local data when --seed is specified', () async {
+    var seedCallCount = 0;
+
+    final result = await runStart(
+      shouldSeed: true,
+      seedSucceeds: true,
+      onSeed: () => seedCallCount++,
+    );
+
+    expect(result, equals(0));
+    expect(seedCallCount, equals(1));
+  });
+
+  test('returns 1 when seeding local data fails', () async {
+    var seedCallCount = 0;
+
+    final result = await runStart(
+      shouldSeed: true,
+      seedSucceeds: false,
+      onSeed: () => seedCallCount++,
+    );
+
+    expect(result, equals(1));
+    expect(seedCallCount, equals(1));
   });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ローカル開発環境の起動時に、`--seed` フラグを指定してテストデータを投入できるようになりました。
  - フラグを指定しない場合、テストデータの投入は実行されません。
  - データ投入に失敗した場合は、終了コード `1` で終了します。

- **ドキュメント**
  - `seed` フラグの使用方法を英語・日本語のヘルプに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->