### PR TITLE
fix: resolve Riverpod analyzer plugin conflict

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,4 +16,4 @@ formatter:
   trailing_commas: preserve
 
 plugins:
-  riverpod_lint: 3.1.2
+  riverpod_lint: 3.1.4


### PR DESCRIPTION
## Summary

- update the Riverpod analyzer plugin to a version compatible with the current Dart Analysis Server
- retain support for the repository's Dart 3.11.5 minimum

## Validation

- dart analyze apps/genuineci_cli
- flutter analyze apps/genuineci_cli
- flutter test (65 tests)
- dart analyze (workspace, exit code 0)
- coderabbit review --agent -t uncommitted --base develop (0 findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 開発時のコード品質チェック環境を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->