### PR TITLE
feat(database): add leaseUntil column to webhookTasks and update schema version to 22

### DIFF
--- a/apps/openci_server/lib/database.dart
+++ b/apps/openci_server/lib/database.dart
@@ -57,7 +57,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase([QueryExecutor? executor]) : super(executor ?? _openConnection());
 
   @override
-  int get schemaVersion => 21;
+  int get schemaVersion => 22;
 
   @override
   MigrationStrategy get migration {
@@ -82,6 +82,9 @@ class AppDatabase extends _$AppDatabase {
         }
         if (from < 21) {
           await m.deleteTable('processed_webhooks');
+        }
+        if (from < 22) {
+          await m.addColumn(webhookTasks, webhookTasks.leaseUntil);
         }
       },
     );

--- a/apps/openci_server/lib/database.g.dart
+++ b/apps/openci_server/lib/database.g.dart
@@ -4838,6 +4838,17 @@ class $WebhookTasksTable extends WebhookTasks
     requiredDuringInsert: false,
     defaultValue: const Constant('pending'),
   );
+  static const VerificationMeta _leaseUntilMeta = const VerificationMeta(
+    'leaseUntil',
+  );
+  @override
+  late final GeneratedColumn<DateTime> leaseUntil = GeneratedColumn<DateTime>(
+    'lease_until',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _retryCountMeta = const VerificationMeta(
     'retryCount',
   );
@@ -4890,6 +4901,7 @@ class $WebhookTasksTable extends WebhookTasks
     eventType,
     payload,
     status,
+    leaseUntil,
     retryCount,
     errorMessage,
     createdAt,
@@ -4940,6 +4952,12 @@ class $WebhookTasksTable extends WebhookTasks
       context.handle(
         _statusMeta,
         status.isAcceptableOrUnknown(data['status']!, _statusMeta),
+      );
+    }
+    if (data.containsKey('lease_until')) {
+      context.handle(
+        _leaseUntilMeta,
+        leaseUntil.isAcceptableOrUnknown(data['lease_until']!, _leaseUntilMeta),
       );
     }
     if (data.containsKey('retry_count')) {
@@ -5002,6 +5020,10 @@ class $WebhookTasksTable extends WebhookTasks
         DriftSqlType.string,
         data['${effectivePrefix}status'],
       )!,
+      leaseUntil: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}lease_until'],
+      ),
       retryCount: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}retry_count'],
@@ -5034,6 +5056,7 @@ class DriftWebhookTask extends DataClass
   final String eventType;
   final String payload;
   final String status;
+  final DateTime? leaseUntil;
   final int retryCount;
   final String? errorMessage;
   final DateTime createdAt;
@@ -5044,6 +5067,7 @@ class DriftWebhookTask extends DataClass
     required this.eventType,
     required this.payload,
     required this.status,
+    this.leaseUntil,
     required this.retryCount,
     this.errorMessage,
     required this.createdAt,
@@ -5057,6 +5081,9 @@ class DriftWebhookTask extends DataClass
     map['event_type'] = Variable<String>(eventType);
     map['payload'] = Variable<String>(payload);
     map['status'] = Variable<String>(status);
+    if (!nullToAbsent || leaseUntil != null) {
+      map['lease_until'] = Variable<DateTime>(leaseUntil);
+    }
     map['retry_count'] = Variable<int>(retryCount);
     if (!nullToAbsent || errorMessage != null) {
       map['error_message'] = Variable<String>(errorMessage);
@@ -5073,6 +5100,9 @@ class DriftWebhookTask extends DataClass
       eventType: Value(eventType),
       payload: Value(payload),
       status: Value(status),
+      leaseUntil: leaseUntil == null && nullToAbsent
+          ? const Value.absent()
+          : Value(leaseUntil),
       retryCount: Value(retryCount),
       errorMessage: errorMessage == null && nullToAbsent
           ? const Value.absent()
@@ -5093,6 +5123,7 @@ class DriftWebhookTask extends DataClass
       eventType: serializer.fromJson<String>(json['eventType']),
       payload: serializer.fromJson<String>(json['payload']),
       status: serializer.fromJson<String>(json['status']),
+      leaseUntil: serializer.fromJson<DateTime?>(json['leaseUntil']),
       retryCount: serializer.fromJson<int>(json['retryCount']),
       errorMessage: serializer.fromJson<String?>(json['errorMessage']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
@@ -5108,6 +5139,7 @@ class DriftWebhookTask extends DataClass
       'eventType': serializer.toJson<String>(eventType),
       'payload': serializer.toJson<String>(payload),
       'status': serializer.toJson<String>(status),
+      'leaseUntil': serializer.toJson<DateTime?>(leaseUntil),
       'retryCount': serializer.toJson<int>(retryCount),
       'errorMessage': serializer.toJson<String?>(errorMessage),
       'createdAt': serializer.toJson<DateTime>(createdAt),
@@ -5121,6 +5153,7 @@ class DriftWebhookTask extends DataClass
     String? eventType,
     String? payload,
     String? status,
+    Value<DateTime?> leaseUntil = const Value.absent(),
     int? retryCount,
     Value<String?> errorMessage = const Value.absent(),
     DateTime? createdAt,
@@ -5131,6 +5164,7 @@ class DriftWebhookTask extends DataClass
     eventType: eventType ?? this.eventType,
     payload: payload ?? this.payload,
     status: status ?? this.status,
+    leaseUntil: leaseUntil.present ? leaseUntil.value : this.leaseUntil,
     retryCount: retryCount ?? this.retryCount,
     errorMessage: errorMessage.present ? errorMessage.value : this.errorMessage,
     createdAt: createdAt ?? this.createdAt,
@@ -5145,6 +5179,9 @@ class DriftWebhookTask extends DataClass
       eventType: data.eventType.present ? data.eventType.value : this.eventType,
       payload: data.payload.present ? data.payload.value : this.payload,
       status: data.status.present ? data.status.value : this.status,
+      leaseUntil: data.leaseUntil.present
+          ? data.leaseUntil.value
+          : this.leaseUntil,
       retryCount: data.retryCount.present
           ? data.retryCount.value
           : this.retryCount,
@@ -5164,6 +5201,7 @@ class DriftWebhookTask extends DataClass
           ..write('eventType: $eventType, ')
           ..write('payload: $payload, ')
           ..write('status: $status, ')
+          ..write('leaseUntil: $leaseUntil, ')
           ..write('retryCount: $retryCount, ')
           ..write('errorMessage: $errorMessage, ')
           ..write('createdAt: $createdAt, ')
@@ -5179,6 +5217,7 @@ class DriftWebhookTask extends DataClass
     eventType,
     payload,
     status,
+    leaseUntil,
     retryCount,
     errorMessage,
     createdAt,
@@ -5193,6 +5232,7 @@ class DriftWebhookTask extends DataClass
           other.eventType == this.eventType &&
           other.payload == this.payload &&
           other.status == this.status &&
+          other.leaseUntil == this.leaseUntil &&
           other.retryCount == this.retryCount &&
           other.errorMessage == this.errorMessage &&
           other.createdAt == this.createdAt &&
@@ -5205,6 +5245,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
   final Value<String> eventType;
   final Value<String> payload;
   final Value<String> status;
+  final Value<DateTime?> leaseUntil;
   final Value<int> retryCount;
   final Value<String?> errorMessage;
   final Value<DateTime> createdAt;
@@ -5216,6 +5257,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
     this.eventType = const Value.absent(),
     this.payload = const Value.absent(),
     this.status = const Value.absent(),
+    this.leaseUntil = const Value.absent(),
     this.retryCount = const Value.absent(),
     this.errorMessage = const Value.absent(),
     this.createdAt = const Value.absent(),
@@ -5228,6 +5270,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
     required String eventType,
     required String payload,
     this.status = const Value.absent(),
+    this.leaseUntil = const Value.absent(),
     this.retryCount = const Value.absent(),
     this.errorMessage = const Value.absent(),
     required DateTime createdAt,
@@ -5245,6 +5288,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
     Expression<String>? eventType,
     Expression<String>? payload,
     Expression<String>? status,
+    Expression<DateTime>? leaseUntil,
     Expression<int>? retryCount,
     Expression<String>? errorMessage,
     Expression<DateTime>? createdAt,
@@ -5257,6 +5301,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
       if (eventType != null) 'event_type': eventType,
       if (payload != null) 'payload': payload,
       if (status != null) 'status': status,
+      if (leaseUntil != null) 'lease_until': leaseUntil,
       if (retryCount != null) 'retry_count': retryCount,
       if (errorMessage != null) 'error_message': errorMessage,
       if (createdAt != null) 'created_at': createdAt,
@@ -5271,6 +5316,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
     Value<String>? eventType,
     Value<String>? payload,
     Value<String>? status,
+    Value<DateTime?>? leaseUntil,
     Value<int>? retryCount,
     Value<String?>? errorMessage,
     Value<DateTime>? createdAt,
@@ -5283,6 +5329,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
       eventType: eventType ?? this.eventType,
       payload: payload ?? this.payload,
       status: status ?? this.status,
+      leaseUntil: leaseUntil ?? this.leaseUntil,
       retryCount: retryCount ?? this.retryCount,
       errorMessage: errorMessage ?? this.errorMessage,
       createdAt: createdAt ?? this.createdAt,
@@ -5308,6 +5355,9 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
     }
     if (status.present) {
       map['status'] = Variable<String>(status.value);
+    }
+    if (leaseUntil.present) {
+      map['lease_until'] = Variable<DateTime>(leaseUntil.value);
     }
     if (retryCount.present) {
       map['retry_count'] = Variable<int>(retryCount.value);
@@ -5335,6 +5385,7 @@ class WebhookTasksCompanion extends UpdateCompanion<DriftWebhookTask> {
           ..write('eventType: $eventType, ')
           ..write('payload: $payload, ')
           ..write('status: $status, ')
+          ..write('leaseUntil: $leaseUntil, ')
           ..write('retryCount: $retryCount, ')
           ..write('errorMessage: $errorMessage, ')
           ..write('createdAt: $createdAt, ')
@@ -10301,6 +10352,7 @@ typedef $$WebhookTasksTableCreateCompanionBuilder =
       required String eventType,
       required String payload,
       Value<String> status,
+      Value<DateTime?> leaseUntil,
       Value<int> retryCount,
       Value<String?> errorMessage,
       required DateTime createdAt,
@@ -10314,6 +10366,7 @@ typedef $$WebhookTasksTableUpdateCompanionBuilder =
       Value<String> eventType,
       Value<String> payload,
       Value<String> status,
+      Value<DateTime?> leaseUntil,
       Value<int> retryCount,
       Value<String?> errorMessage,
       Value<DateTime> createdAt,
@@ -10352,6 +10405,11 @@ class $$WebhookTasksTableFilterComposer
 
   ColumnFilters<String> get status => $composableBuilder(
     column: $table.status,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10410,6 +10468,11 @@ class $$WebhookTasksTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<DateTime> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get retryCount => $composableBuilder(
     column: $table.retryCount,
     builder: (column) => ColumnOrderings(column),
@@ -10456,6 +10519,11 @@ class $$WebhookTasksTableAnnotationComposer
 
   GeneratedColumn<String> get status =>
       $composableBuilder(column: $table.status, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get leaseUntil => $composableBuilder(
+    column: $table.leaseUntil,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<int> get retryCount => $composableBuilder(
     column: $table.retryCount,
@@ -10510,6 +10578,7 @@ class $$WebhookTasksTableTableManager
                 Value<String> eventType = const Value.absent(),
                 Value<String> payload = const Value.absent(),
                 Value<String> status = const Value.absent(),
+                Value<DateTime?> leaseUntil = const Value.absent(),
                 Value<int> retryCount = const Value.absent(),
                 Value<String?> errorMessage = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
@@ -10521,6 +10590,7 @@ class $$WebhookTasksTableTableManager
                 eventType: eventType,
                 payload: payload,
                 status: status,
+                leaseUntil: leaseUntil,
                 retryCount: retryCount,
                 errorMessage: errorMessage,
                 createdAt: createdAt,
@@ -10534,6 +10604,7 @@ class $$WebhookTasksTableTableManager
                 required String eventType,
                 required String payload,
                 Value<String> status = const Value.absent(),
+                Value<DateTime?> leaseUntil = const Value.absent(),
                 Value<int> retryCount = const Value.absent(),
                 Value<String?> errorMessage = const Value.absent(),
                 required DateTime createdAt,
@@ -10545,6 +10616,7 @@ class $$WebhookTasksTableTableManager
                 eventType: eventType,
                 payload: payload,
                 status: status,
+                leaseUntil: leaseUntil,
                 retryCount: retryCount,
                 errorMessage: errorMessage,
                 createdAt: createdAt,

--- a/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
@@ -4,6 +4,8 @@ import 'package:openci_server/webhook_task/webhook_task_table.dart';
 
 part 'webhook_task_dao.g.dart';
 
+const webhookTaskLeaseDuration = Duration(minutes: 5);
+
 @DriftAccessor(tables: [WebhookTasks])
 class WebhookTaskDao extends DatabaseAccessor<AppDatabase>
     with _$WebhookTaskDaoMixin {
@@ -11,17 +13,28 @@ class WebhookTaskDao extends DatabaseAccessor<AppDatabase>
 
   Future<DriftWebhookTask?> claimNextWebhookTask() async {
     return db.transaction(() async {
+      final now = DateTime.now().toUtc();
       final isPostgres =
           db.attachedDatabase.executor.dialect == SqlDialect.postgres;
+      final leaseUntilVariable = isPostgres ? r'$1' : '?';
       final sql =
           '''
         SELECT * FROM webhook_tasks
         WHERE status = 'pending'
+          OR (
+            status = 'processing'
+            AND (lease_until IS NULL OR lease_until <= $leaseUntilVariable)
+          )
         ORDER BY created_at ASC
         LIMIT 1
         ${isPostgres ? 'FOR UPDATE SKIP LOCKED' : ''}
       ''';
-      final results = await db.customSelect(sql).get();
+      final results = await db
+          .customSelect(
+            sql,
+            variables: [Variable<DateTime>(now)],
+          )
+          .get();
       if (results.isEmpty) return null;
 
       final row = results.first;
@@ -29,7 +42,8 @@ class WebhookTaskDao extends DatabaseAccessor<AppDatabase>
 
       final updated = task.copyWith(
         status: 'processing',
-        updatedAt: DateTime.now().toUtc(),
+        leaseUntil: Value(now.add(webhookTaskLeaseDuration)),
+        updatedAt: now,
       );
       await updateWebhookTask(updated);
       return updated;

--- a/apps/openci_server/lib/webhook_task/webhook_task_table.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_table.dart
@@ -9,6 +9,7 @@ class WebhookTasks extends Table {
   TextColumn get status => text().withDefault(
     const Constant('pending'),
   )();
+  DateTimeColumn get leaseUntil => dateTime().nullable()();
   IntColumn get retryCount => integer().withDefault(const Constant(0))();
   TextColumn get errorMessage => text().nullable()();
   DateTimeColumn get createdAt => dateTime()();

--- a/apps/openci_server/routes/webhooks/tasks/[id]/process.dart
+++ b/apps/openci_server/routes/webhooks/tasks/[id]/process.dart
@@ -57,14 +57,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
     );
 
     if (event.isDeleted) {
-      await (db.update(
-        db.webhookTasks,
-      )..where((tbl) => tbl.id.equals(taskId))).write(
-        WebhookTasksCompanion(
-          status: const Value('completed'),
-          updatedAt: Value(DateTime.now().toUtc()),
-        ),
-      );
+      await _completeTask(db, taskId);
       return Response.json(
         body: {
           'success': true,
@@ -86,14 +79,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
     }
 
     if (targetTeam == null) {
-      await (db.update(
-        db.webhookTasks,
-      )..where((tbl) => tbl.id.equals(taskId))).write(
-        WebhookTasksCompanion(
-          status: const Value('completed'),
-          updatedAt: Value(DateTime.now().toUtc()),
-        ),
-      );
+      await _completeTask(db, taskId);
       return Response.json(
         body: {
           'success': true,
@@ -129,14 +115,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
     );
 
     if (files.isEmpty) {
-      await (db.update(
-        db.webhookTasks,
-      )..where((tbl) => tbl.id.equals(taskId))).write(
-        WebhookTasksCompanion(
-          status: const Value('completed'),
-          updatedAt: Value(DateTime.now().toUtc()),
-        ),
-      );
+      await _completeTask(db, taskId);
       return Response.json(
         body: {
           'success': true,
@@ -162,14 +141,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
     }
 
     if (matchingWorkflows.isEmpty) {
-      await (db.update(
-        db.webhookTasks,
-      )..where((tbl) => tbl.id.equals(taskId))).write(
-        WebhookTasksCompanion(
-          status: const Value('completed'),
-          updatedAt: Value(DateTime.now().toUtc()),
-        ),
-      );
+      await _completeTask(db, taskId);
       return Response.json(
         body: {
           'success': true,
@@ -182,6 +154,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
 
     // 5. Create BuildJob records in DB
     final createdJobIds = <String>[];
+    final createdJobs = <DriftBuildJob>[];
     for (final workflow in matchingWorkflows) {
       final jobId = const Uuid().v4();
       final now = DateTime.now().toUtc();
@@ -209,19 +182,17 @@ Future<Response> _post(RequestContext context, String taskId) async {
         installationId: Value(event.installationId.toString()),
       );
 
-      await db.buildJobDao.insertBuildJob(driftJob);
+      createdJobs.add(driftJob);
       createdJobIds.add(jobId);
     }
 
-    // 6. Mark task as completed
-    await (db.update(
-      db.webhookTasks,
-    )..where((tbl) => tbl.id.equals(taskId))).write(
-      WebhookTasksCompanion(
-        status: const Value('completed'),
-        updatedAt: Value(DateTime.now().toUtc()),
-      ),
-    );
+    // 6. Persist jobs and task completion atomically.
+    await db.transaction(() async {
+      for (final job in createdJobs) {
+        await db.buildJobDao.insertBuildJob(job);
+      }
+      await _completeTask(db, taskId);
+    });
 
     return Response.json(
       body: {
@@ -238,6 +209,7 @@ Future<Response> _post(RequestContext context, String taskId) async {
       )..where((tbl) => tbl.id.equals(taskId))).write(
         WebhookTasksCompanion(
           status: const Value('failed'),
+          leaseUntil: const Value(null),
           errorMessage: Value('$e\n$s'),
           updatedAt: Value(DateTime.now().toUtc()),
         ),
@@ -250,4 +222,16 @@ Future<Response> _post(RequestContext context, String taskId) async {
       logMessage: 'Failed to process webhook task $taskId',
     );
   }
+}
+
+Future<void> _completeTask(AppDatabase db, String taskId) {
+  return (db.update(
+    db.webhookTasks,
+  )..where((tbl) => tbl.id.equals(taskId))).write(
+    WebhookTasksCompanion(
+      status: const Value('completed'),
+      leaseUntil: const Value(null),
+      updatedAt: Value(DateTime.now().toUtc()),
+    ),
+  );
 }

--- a/apps/openci_server/test/db/database_migration_test.dart
+++ b/apps/openci_server/test/db/database_migration_test.dart
@@ -6,55 +6,62 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  test('migration from schema 20 drops processed_webhooks', () async {
-    final tempDirectory = Directory.systemTemp.createTempSync(
-      'openci-database-migration-test-',
-    );
-    final databaseFile = File(p.join(tempDirectory.path, 'database.sqlite'));
-    AppDatabase? database;
+  test(
+    'migration from schema 20 drops processed_webhooks and adds lease_until',
+    () async {
+      final tempDirectory = Directory.systemTemp.createTempSync(
+        'openci-database-migration-test-',
+      );
+      final databaseFile = File(p.join(tempDirectory.path, 'database.sqlite'));
+      AppDatabase? database;
 
-    try {
-      database = AppDatabase(NativeDatabase(databaseFile));
-      await database.customStatement('''
+      try {
+        database = AppDatabase(NativeDatabase(databaseFile));
+        await database.customStatement('''
         CREATE TABLE IF NOT EXISTS processed_webhooks (
           delivery_id TEXT NOT NULL PRIMARY KEY,
           processed_at INTEGER NOT NULL
         )
       ''');
-      final now = DateTime.now().toUtc();
-      await database.webhookTaskDao.insertWebhookTask(
-        DriftWebhookTask(
-          id: 'retained-task',
-          deliveryId: 'retained-delivery',
-          eventType: 'push',
-          payload: '{"ref":"refs/heads/main"}',
-          status: 'pending',
-          retryCount: 0,
-          createdAt: now,
-          updatedAt: now,
-        ),
-      );
-      await database.customStatement('PRAGMA user_version = 20');
-      await database.close();
-      database = null;
+        final now = DateTime.now().toUtc();
+        await database.webhookTaskDao.insertWebhookTask(
+          DriftWebhookTask(
+            id: 'retained-task',
+            deliveryId: 'retained-delivery',
+            eventType: 'push',
+            payload: '{"ref":"refs/heads/main"}',
+            status: 'pending',
+            retryCount: 0,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+        await database.customStatement(
+          'ALTER TABLE webhook_tasks DROP COLUMN lease_until',
+        );
+        await database.customStatement('PRAGMA user_version = 20');
+        await database.close();
+        database = null;
 
-      database = AppDatabase(NativeDatabase(databaseFile));
-      final processedWebhookTables = await database.customSelect(
-        '''
+        database = AppDatabase(NativeDatabase(databaseFile));
+        final processedWebhookTables = await database.customSelect(
+          '''
           SELECT name
           FROM sqlite_master
           WHERE type = 'table' AND name = 'processed_webhooks'
         ''',
-      ).get();
+        ).get();
 
-      expect(processedWebhookTables, isEmpty);
-      expect(
-        await database.webhookTaskDao.getWebhookTask('retained-task'),
-        isNotNull,
-      );
-    } finally {
-      await database?.close();
-      tempDirectory.deleteSync(recursive: true);
-    }
-  });
+        expect(processedWebhookTables, isEmpty);
+        final retainedTask = await database.webhookTaskDao.getWebhookTask(
+          'retained-task',
+        );
+        expect(retainedTask, isNotNull);
+        expect(retainedTask?.leaseUntil, isNull);
+      } finally {
+        await database?.close();
+        tempDirectory.deleteSync(recursive: true);
+      }
+    },
+  );
 }

--- a/apps/openci_server/test/routes/webhooks/tasks/process_test.dart
+++ b/apps/openci_server/test/routes/webhooks/tasks/process_test.dart
@@ -117,6 +117,7 @@ Future<void> main() async {
 
       final savedTask = await db.webhookTaskDao.getWebhookTask(task.id);
       expect(savedTask?.status, equals('completed'));
+      expect(savedTask?.leaseUntil, isNull);
 
       final jobs = await db.select(db.buildJobs).get();
       expect(jobs, hasLength(1));
@@ -131,6 +132,47 @@ Future<void> main() async {
       expect(jobs.single.branch, equals('main'));
       expect(jobs.single.installationId, equals('98765'));
     });
+
+    test(
+      'rolls back BuildJobs when completing the webhook task fails',
+      () async {
+        final task = await _insertPushTask(db, id: 'completion-failure-task');
+        final client = _githubClientWithWorkflow(
+          '''
+import 'package:genuine_ci/genuine_ci.dart';
+
+Future<void> main() async {
+  await GenuineCI.init(
+    workflowName: 'Dashboard CI',
+    ciTrigger: CiTrigger.push(branch: 'main'),
+  );
+}
+''',
+        );
+        await db.customStatement('''
+          CREATE TRIGGER reject_webhook_task_completion
+          BEFORE UPDATE OF status ON webhook_tasks
+          WHEN NEW.status = 'completed'
+          BEGIN
+            SELECT RAISE(ABORT, 'forced webhook task completion failure');
+          END;
+        ''');
+
+        final response = await _processTask(
+          db: db,
+          taskId: task.id,
+          environment: environment,
+          client: client,
+        );
+
+        expect(response.statusCode, equals(HttpStatus.internalServerError));
+        expect(await db.select(db.buildJobs).get(), isEmpty);
+
+        final savedTask = await db.webhookTaskDao.getWebhookTask(task.id);
+        expect(savedTask?.status, equals('failed'));
+        expect(savedTask?.leaseUntil, isNull);
+      },
+    );
 
     test(
       'completes the task without creating a job when no workflow matches',
@@ -165,6 +207,7 @@ Future<void> main() async {
 
         final savedTask = await db.webhookTaskDao.getWebhookTask(task.id);
         expect(savedTask?.status, equals('completed'));
+        expect(savedTask?.leaseUntil, isNull);
         expect(await db.select(db.buildJobs).get(), isEmpty);
       },
     );
@@ -190,6 +233,7 @@ Future<void> main() async {
 
       final savedTask = await db.webhookTaskDao.getWebhookTask(task.id);
       expect(savedTask?.status, equals('failed'));
+      expect(savedTask?.leaseUntil, isNull);
       expect(savedTask?.errorMessage, contains('GitHub unavailable'));
       expect(await db.select(db.buildJobs).get(), isEmpty);
     });
@@ -219,6 +263,7 @@ Future<DriftWebhookTask> _insertPushTask(
       'installation': {'id': 98765},
     }),
     status: 'processing',
+    leaseUntil: now.add(const Duration(minutes: 5)),
     retryCount: 0,
     createdAt: now,
     updatedAt: now,

--- a/apps/openci_server/test/webhook_task/webhook_task_dao_test.dart
+++ b/apps/openci_server/test/webhook_task/webhook_task_dao_test.dart
@@ -1,0 +1,98 @@
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_dao.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WebhookTaskDao.claimNextWebhookTask', () {
+    late AppDatabase db;
+
+    setUp(() {
+      db = AppDatabase(NativeDatabase.memory());
+    });
+
+    tearDown(() => db.close());
+
+    test('claims a pending task and assigns a lease', () async {
+      await _insertTask(db, status: 'pending');
+      final beforeClaim = DateTime.now().toUtc();
+
+      final claimed = await db.webhookTaskDao.claimNextWebhookTask();
+
+      final afterClaim = DateTime.now().toUtc();
+      expect(claimed, isNotNull);
+      expect(claimed?.status, equals('processing'));
+      expect(claimed?.retryCount, isZero);
+      expect(
+        claimed?.leaseUntil?.isBefore(
+          beforeClaim.add(webhookTaskLeaseDuration),
+        ),
+        isFalse,
+      );
+      expect(
+        claimed?.leaseUntil?.isAfter(
+          afterClaim.add(webhookTaskLeaseDuration),
+        ),
+        isFalse,
+      );
+    });
+
+    test('does not claim a processing task with an active lease', () async {
+      await _insertTask(
+        db,
+        status: 'processing',
+        leaseUntil: DateTime.now().toUtc().add(const Duration(hours: 1)),
+      );
+
+      final claimed = await db.webhookTaskDao.claimNextWebhookTask();
+
+      expect(claimed, isNull);
+    });
+
+    test('reclaims a processing task with an expired lease', () async {
+      await _insertTask(
+        db,
+        status: 'processing',
+        leaseUntil: DateTime.now().toUtc().subtract(const Duration(hours: 1)),
+      );
+      final beforeClaim = DateTime.now().toUtc();
+
+      final claimed = await db.webhookTaskDao.claimNextWebhookTask();
+
+      expect(claimed?.id, equals('task-1'));
+      expect(claimed?.status, equals('processing'));
+      expect(claimed?.retryCount, isZero);
+      expect(claimed?.leaseUntil?.isAfter(beforeClaim), isTrue);
+    });
+
+    test('reclaims a legacy processing task without a lease', () async {
+      await _insertTask(db, status: 'processing');
+
+      final claimed = await db.webhookTaskDao.claimNextWebhookTask();
+
+      expect(claimed?.id, equals('task-1'));
+      expect(claimed?.leaseUntil, isNotNull);
+    });
+  });
+}
+
+Future<void> _insertTask(
+  AppDatabase db, {
+  required String status,
+  DateTime? leaseUntil,
+}) {
+  final now = DateTime.now().toUtc();
+  return db.webhookTaskDao.insertWebhookTask(
+    DriftWebhookTask(
+      id: 'task-1',
+      deliveryId: 'delivery-1',
+      eventType: 'push',
+      payload: '{}',
+      status: status,
+      leaseUntil: leaseUntil,
+      retryCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Webhookタスクに5分間のリース期限を設定し、処理中のタスクを管理できるようになりました。
  * 期限切れまたはリース未設定のタスクを再取得できるようになりました。
* **バグ修正**
  * Webhookタスクの完了・失敗時にリース期限が確実に解除されます。
  * ジョブ作成やタスク更新に失敗した場合、関連処理が適切にロールバックされるようになりました。
* **データベース**
  * データベースを更新し、既存のWebhookタスクとの互換性を維持しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->