### PR TITLE
feat(webhooks): implement complete and fail endpoints for webhook tasks

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_plan.dart
+++ b/apps/openci_server/lib/build_job/build_job_plan.dart
@@ -1,0 +1,190 @@
+import 'package:openci_shared/openci_shared.dart';
+
+class BuildJobPlan {
+  const BuildJobPlan({
+    required this.owner,
+    required this.repo,
+    required this.workflowName,
+    required this.workflowFileName,
+    required this.teamId,
+    required this.commitSha,
+    required this.branch,
+    required this.runsOn,
+    required this.githubBaseUrl,
+    required this.installationId,
+    this.workflowId,
+    this.commitMessage,
+    this.pullRequestNumber,
+    this.tagName,
+    this.jobKey,
+    this.workflowJobKey,
+    this.matrix,
+    this.matrixLabel,
+    this.workflowRunId,
+    this.needs,
+  });
+
+  factory BuildJobPlan.fromJson(Map<String, Object?> json) {
+    final unsupportedFields = json.keys
+        .where((key) => !_supportedFields.contains(key))
+        .toList();
+    if (unsupportedFields.isNotEmpty) {
+      throw FormatException(
+        'Unsupported fields: ${unsupportedFields.join(', ')}',
+      );
+    }
+
+    return BuildJobPlan(
+      owner: _requiredString(json, 'owner'),
+      repo: _requiredString(json, 'repo'),
+      workflowName: _requiredString(json, 'workflowName'),
+      workflowFileName: _requiredString(json, 'workflowFileName'),
+      teamId: _requiredString(json, 'teamId'),
+      workflowId: _optionalString(json, 'workflowId'),
+      commitSha: _requiredString(json, 'commitSha'),
+      commitMessage: _optionalString(json, 'commitMessage'),
+      pullRequestNumber: _optionalInt(json, 'pullRequestNumber'),
+      tagName: _optionalString(json, 'tagName'),
+      branch: _requiredString(json, 'branch'),
+      jobKey: _optionalString(json, 'jobKey'),
+      workflowJobKey: _optionalString(json, 'workflowJobKey'),
+      matrix: _optionalMap(json, 'matrix'),
+      matrixLabel: _optionalString(json, 'matrixLabel'),
+      workflowRunId: _optionalString(json, 'workflowRunId'),
+      needs: _optionalStringList(json, 'needs'),
+      runsOn: _requiredString(json, 'runsOn'),
+      githubBaseUrl: _requiredString(json, 'githubBaseUrl'),
+      installationId: _requiredString(json, 'installationId'),
+    );
+  }
+
+  static const _supportedFields = <String>{
+    'owner',
+    'repo',
+    'workflowName',
+    'workflowFileName',
+    'teamId',
+    'workflowId',
+    'commitSha',
+    'commitMessage',
+    'pullRequestNumber',
+    'tagName',
+    'branch',
+    'jobKey',
+    'workflowJobKey',
+    'matrix',
+    'matrixLabel',
+    'workflowRunId',
+    'needs',
+    'runsOn',
+    'githubBaseUrl',
+    'installationId',
+  };
+
+  final String owner;
+  final String repo;
+  final String workflowName;
+  final String workflowFileName;
+  final String teamId;
+  final String? workflowId;
+  final String commitSha;
+  final String? commitMessage;
+  final int? pullRequestNumber;
+  final String? tagName;
+  final String branch;
+  final String? jobKey;
+  final String? workflowJobKey;
+  final Map<String, Object?>? matrix;
+  final String? matrixLabel;
+  final String? workflowRunId;
+  final List<String>? needs;
+  final String runsOn;
+  final String githubBaseUrl;
+  final String installationId;
+
+  BuildJob createBuildJob({
+    required String id,
+    required DateTime timestamp,
+  }) {
+    return BuildJob(
+      id: id,
+      status: BuildJobStatus.QUEUED,
+      owner: owner,
+      repo: repo,
+      workflowName: workflowName,
+      workflowFileName: workflowFileName,
+      teamId: teamId,
+      workflowId: workflowId,
+      commitSha: commitSha,
+      commitMessage: commitMessage,
+      pullRequestNumber: pullRequestNumber,
+      runCount: 0,
+      tagName: tagName,
+      branch: branch,
+      jobKey: jobKey,
+      workflowJobKey: workflowJobKey,
+      matrix: matrix,
+      matrixLabel: matrixLabel,
+      workflowRunId: workflowRunId,
+      needs: needs,
+      runsOn: runsOn,
+      githubBaseUrl: githubBaseUrl,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    );
+  }
+}
+
+String _requiredString(Map<String, Object?> json, String field) {
+  final value = json[field];
+  if (value is! String || value.trim().isEmpty) {
+    throw FormatException('$field must be a non-empty string');
+  }
+  return value;
+}
+
+String? _optionalString(Map<String, Object?> json, String field) {
+  final value = json[field];
+  if (value == null) return null;
+  if (value is! String) {
+    throw FormatException('$field must be a string');
+  }
+  return value;
+}
+
+int? _optionalInt(Map<String, Object?> json, String field) {
+  final value = json[field];
+  if (value == null) return null;
+  if (value is! int) {
+    throw FormatException('$field must be an integer');
+  }
+  return value;
+}
+
+Map<String, Object?>? _optionalMap(
+  Map<String, Object?> json,
+  String field,
+) {
+  final value = json[field];
+  if (value == null) return null;
+  if (value is! Map) {
+    throw FormatException('$field must be an object');
+  }
+  try {
+    return Map<String, Object?>.from(value);
+  } catch (_) {
+    throw FormatException('$field must have string keys');
+  }
+}
+
+List<String>? _optionalStringList(
+  Map<String, Object?> json,
+  String field,
+) {
+  final value = json[field];
+  if (value == null) return null;
+  if (value is! List || value.any((item) => item is! String)) {
+    throw FormatException('$field must be a list of strings');
+  }
+  return value.cast<String>();
+}

--- a/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
+++ b/apps/openci_server/lib/webhook_task/webhook_task_dao.dart
@@ -82,7 +82,22 @@ class WebhookTaskDao extends DatabaseAccessor<AppDatabase>
         errorMessage: Value(errorMessage),
         updatedAt: now,
       );
-      await updateWebhookTask(updated);
+      final updatedCount =
+          await (update(webhookTasks)..where(
+                (row) =>
+                    row.id.equals(taskId) & row.status.equals('processing'),
+              ))
+              .write(
+                WebhookTasksCompanion(
+                  status: Value(updated.status),
+                  retryCount: Value(updated.retryCount),
+                  leaseUntil: const Value(null),
+                  nextRetryAt: Value(updated.nextRetryAt),
+                  errorMessage: Value(updated.errorMessage),
+                  updatedAt: Value(updated.updatedAt),
+                ),
+              );
+      if (updatedCount == 0) return getWebhookTask(taskId);
       return updated;
     });
   }

--- a/apps/openci_server/routes/webhooks/tasks/[id]/complete.dart
+++ b/apps/openci_server/routes/webhooks/tasks/[id]/complete.dart
@@ -1,0 +1,213 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:drift/drift.dart';
+import 'package:openci_server/build_job/build_job_plan.dart';
+import 'package:openci_server/build_job/build_job_mapper.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/request/error_handler.dart';
+import 'package:openci_server/request/request_extension.dart';
+import 'package:uuid/uuid.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id) {
+  return switch (context.request.method) {
+    HttpMethod.post => _post(context, id),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _post(RequestContext context, String taskId) async {
+  final db = context.read<AppDatabase>();
+  final uid = context.read<String?>();
+
+  if (uid == null) {
+    return Response.json(
+      statusCode: HttpStatus.unauthorized,
+      body: {'success': false, 'error': 'Authentication required'},
+    );
+  }
+  if (uid != 'system-job-processor') {
+    return Response.json(
+      statusCode: HttpStatus.forbidden,
+      body: {'success': false, 'error': 'Internal API key required'},
+    );
+  }
+
+  final task = await db.webhookTaskDao.getWebhookTask(taskId);
+  if (task == null) {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'success': false, 'error': 'WebhookTask not found'},
+    );
+  }
+  if (task.status == 'completed') {
+    return _completionResponse(alreadyCompleted: true);
+  }
+  if (task.status != 'processing') {
+    return _invalidStatusResponse(task.status);
+  }
+
+  final Map<String, dynamic> payload;
+  try {
+    payload = await context.jsonBody();
+  } on BadRequestException catch (e) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {'success': false, 'error': e.message},
+    );
+  }
+
+  final List<BuildJobPlan> jobs;
+  try {
+    jobs = _parseJobs(payload);
+  } catch (e) {
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {'success': false, 'error': 'Invalid jobs: $e'},
+    );
+  }
+
+  try {
+    final result = await _completeTask(
+      db: db,
+      taskId: taskId,
+      jobs: jobs,
+    );
+    return _completionResponse(
+      jobIds: result.jobIds,
+      alreadyCompleted: result.alreadyCompleted,
+    );
+  } on _WebhookTaskNotFound {
+    return Response.json(
+      statusCode: HttpStatus.notFound,
+      body: {'success': false, 'error': 'WebhookTask not found'},
+    );
+  } on _InvalidWebhookTaskStatus catch (e) {
+    return _invalidStatusResponse(e.status);
+  } catch (e, s) {
+    try {
+      await db.webhookTaskDao.recordWebhookTaskFailure(
+        taskId: taskId,
+        errorMessage: '$e\n$s',
+      );
+    } catch (_) {}
+
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to complete webhook task $taskId',
+    );
+  }
+}
+
+List<BuildJobPlan> _parseJobs(Map<String, dynamic> payload) {
+  final rawJobs = payload['jobs'];
+  if (rawJobs is! List) {
+    throw const FormatException('jobs must be a list');
+  }
+
+  return rawJobs.indexed.map((entry) {
+    final (index, rawJob) = entry;
+    if (rawJob is! Map) {
+      throw FormatException('jobs[$index] must be an object');
+    }
+
+    return BuildJobPlan.fromJson(Map<String, Object?>.from(rawJob));
+  }).toList();
+}
+
+Future<_CompletionResult> _completeTask({
+  required AppDatabase db,
+  required String taskId,
+  required List<BuildJobPlan> jobs,
+}) async {
+  var alreadyCompleted = false;
+  final createdJobIds = <String>[];
+
+  await db.transaction(() async {
+    final now = DateTime.now().toUtc();
+    final updatedCount =
+        await (db.update(db.webhookTasks)..where(
+              (task) =>
+                  task.id.equals(taskId) & task.status.equals('processing'),
+            ))
+            .write(
+              WebhookTasksCompanion(
+                status: const Value('completed'),
+                leaseUntil: const Value(null),
+                nextRetryAt: const Value(null),
+                errorMessage: const Value(null),
+                updatedAt: Value(now),
+              ),
+            );
+
+    if (updatedCount == 0) {
+      final currentTask = await db.webhookTaskDao.getWebhookTask(taskId);
+      if (currentTask == null) throw const _WebhookTaskNotFound();
+      if (currentTask.status == 'completed') {
+        alreadyCompleted = true;
+        return;
+      }
+      throw _InvalidWebhookTaskStatus(currentTask.status);
+    }
+
+    for (final plan in jobs) {
+      final id = const Uuid().v4();
+      final job = plan.createBuildJob(id: id, timestamp: now);
+      await db.buildJobDao.insertBuildJob(
+        job.toDrift(installationId: plan.installationId),
+      );
+      createdJobIds.add(id);
+    }
+  });
+
+  return _CompletionResult(
+    jobIds: alreadyCompleted ? const [] : createdJobIds,
+    alreadyCompleted: alreadyCompleted,
+  );
+}
+
+Response _completionResponse({
+  List<String> jobIds = const [],
+  required bool alreadyCompleted,
+}) {
+  return Response.json(
+    body: {
+      'success': true,
+      'jobs_created': jobIds.length,
+      'job_ids': jobIds,
+      'already_completed': alreadyCompleted,
+    },
+  );
+}
+
+Response _invalidStatusResponse(String status) {
+  return Response.json(
+    statusCode: HttpStatus.conflict,
+    body: {
+      'success': false,
+      'error': 'WebhookTask must be processing (current status: $status)',
+    },
+  );
+}
+
+class _CompletionResult {
+  const _CompletionResult({
+    required this.jobIds,
+    required this.alreadyCompleted,
+  });
+
+  final List<String> jobIds;
+  final bool alreadyCompleted;
+}
+
+class _WebhookTaskNotFound implements Exception {
+  const _WebhookTaskNotFound();
+}
+
+class _InvalidWebhookTaskStatus implements Exception {
+  const _InvalidWebhookTaskStatus(this.status);
+
+  final String status;
+}

--- a/apps/openci_server/routes/webhooks/tasks/[id]/fail.dart
+++ b/apps/openci_server/routes/webhooks/tasks/[id]/fail.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/request/error_handler.dart';
+import 'package:openci_server/request/request_extension.dart';
+
+FutureOr<Response> onRequest(RequestContext context, String id) {
+  return switch (context.request.method) {
+    HttpMethod.post => _post(context, id),
+    _ => Response(statusCode: HttpStatus.methodNotAllowed),
+  };
+}
+
+Future<Response> _post(RequestContext context, String taskId) async {
+  try {
+    final db = context.read<AppDatabase>();
+    final uid = context.read<String?>();
+
+    if (uid == null) {
+      return Response.json(
+        statusCode: HttpStatus.unauthorized,
+        body: {'success': false, 'error': 'Authentication required'},
+      );
+    }
+    if (uid != 'system-job-processor') {
+      return Response.json(
+        statusCode: HttpStatus.forbidden,
+        body: {'success': false, 'error': 'Internal API key required'},
+      );
+    }
+
+    final Map<String, dynamic> payload;
+    try {
+      payload = await context.jsonBody();
+    } on BadRequestException catch (e) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {'success': false, 'error': e.message},
+      );
+    }
+
+    final errorMessage = payload['errorMessage'];
+    if (errorMessage is! String || errorMessage.trim().isEmpty) {
+      return Response.json(
+        statusCode: HttpStatus.badRequest,
+        body: {
+          'success': false,
+          'error': 'errorMessage must be a non-empty string',
+        },
+      );
+    }
+
+    final currentTask = await db.webhookTaskDao.getWebhookTask(taskId);
+    if (currentTask == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'WebhookTask not found'},
+      );
+    }
+    if (currentTask.status == 'pending') {
+      return _invalidStatusResponse(currentTask.status);
+    }
+
+    final updated = await db.webhookTaskDao.recordWebhookTaskFailure(
+      taskId: taskId,
+      errorMessage: errorMessage,
+    );
+    if (updated == null) {
+      return Response.json(
+        statusCode: HttpStatus.notFound,
+        body: {'success': false, 'error': 'WebhookTask not found'},
+      );
+    }
+    if (updated.status == 'pending' || updated.status == 'processing') {
+      return _invalidStatusResponse(updated.status);
+    }
+
+    return Response.json(
+      body: {
+        'success': true,
+        'status': updated.status,
+        'retry_count': updated.retryCount,
+        'next_retry_at': updated.nextRetryAt?.toIso8601String(),
+      },
+    );
+  } catch (e, s) {
+    return handleRouteException(
+      e,
+      s,
+      logMessage: 'Failed to record webhook task failure $taskId',
+    );
+  }
+}
+
+Response _invalidStatusResponse(String status) {
+  return Response.json(
+    statusCode: HttpStatus.conflict,
+    body: {
+      'success': false,
+      'error': 'WebhookTask must be processing (current status: $status)',
+    },
+  );
+}

--- a/apps/openci_server/test/routes/webhooks/tasks/complete_test.dart
+++ b/apps/openci_server/test/routes/webhooks/tasks/complete_test.dart
@@ -1,0 +1,256 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+import '../../../../routes/webhooks/tasks/[id]/complete.dart' as route;
+
+void main() {
+  group('POST /webhooks/tasks/[id]/complete', () {
+    late AppDatabase db;
+
+    setUp(() {
+      db = AppDatabase(NativeDatabase.memory());
+    });
+
+    tearDown(() => db.close());
+
+    test('requires the internal API identity', () async {
+      await _insertTask(db, status: 'processing');
+
+      final unauthenticated = await _completeTask(
+        db: db,
+        uid: null,
+        jobs: const [],
+      );
+      final regularUser = await _completeTask(
+        db: db,
+        uid: 'user-123',
+        jobs: const [],
+      );
+
+      expect(unauthenticated.statusCode, equals(HttpStatus.unauthorized));
+      expect(regularUser.statusCode, equals(HttpStatus.forbidden));
+    });
+
+    test('returns 404 when the webhook task does not exist', () async {
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: const [],
+      );
+
+      expect(response.statusCode, equals(HttpStatus.notFound));
+    });
+
+    test('returns 400 when jobs is not a list', () async {
+      await _insertTask(db, status: 'processing');
+
+      final response = await _request(
+        db: db,
+        uid: 'system-job-processor',
+        body: jsonEncode({'jobs': 'invalid'}),
+      );
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      expect(await db.select(db.buildJobs).get(), isEmpty);
+    });
+
+    test('stores BuildJobs and completes the task atomically', () async {
+      await _insertTask(
+        db,
+        status: 'processing',
+        leaseUntil: DateTime.now().toUtc().add(const Duration(minutes: 5)),
+        errorMessage: 'old failure',
+      );
+      final beforeRequest = DateTime.now().toUtc();
+
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: [_buildJobPlan()],
+      );
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      expect(body['jobs_created'], equals(1));
+      expect(body['job_ids'], hasLength(1));
+      expect(body['already_completed'], isFalse);
+
+      final savedTask = await db.webhookTaskDao.getWebhookTask('task-1');
+      expect(savedTask?.status, equals('completed'));
+      expect(savedTask?.leaseUntil, isNull);
+      expect(savedTask?.nextRetryAt, isNull);
+      expect(savedTask?.errorMessage, isNull);
+
+      final jobs = await db.select(db.buildJobs).get();
+      expect(jobs, hasLength(1));
+      expect(jobs.single.id, equals((body['job_ids'] as List).single));
+      expect(jobs.single.id, isNotEmpty);
+      expect(jobs.single.status, equals(BuildJobStatus.QUEUED));
+      expect(jobs.single.runCount, isZero);
+      expect(jobs.single.installationId, equals('98765'));
+      expect(
+        jobs.single.createdAt.isBefore(
+          beforeRequest.subtract(const Duration(seconds: 1)),
+        ),
+        isFalse,
+      );
+      expect(jobs.single.updatedAt, equals(jobs.single.createdAt));
+    });
+
+    test('rejects persistence fields owned by the server', () async {
+      await _insertTask(db, status: 'processing');
+
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: [
+          {..._buildJobPlan(), 'id': 'planner-generated-id'},
+        ],
+      );
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      expect(await db.select(db.buildJobs).get(), isEmpty);
+      expect(
+        (await db.webhookTaskDao.getWebhookTask('task-1'))?.status,
+        equals('processing'),
+      );
+    });
+
+    test('accepts an empty job list and completes the task', () async {
+      await _insertTask(db, status: 'processing');
+
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: const [],
+      );
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      expect(
+        (await db.webhookTaskDao.getWebhookTask('task-1'))?.status,
+        equals('completed'),
+      );
+      expect(await db.select(db.buildJobs).get(), isEmpty);
+    });
+
+    test('does not create jobs when the task is already completed', () async {
+      await _insertTask(db, status: 'processing');
+      final firstResponse = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: [_buildJobPlan(workflowName: 'Original CI')],
+      );
+      final firstBody = await firstResponse.json() as Map<String, dynamic>;
+      final originalJobId = (firstBody['job_ids'] as List).single;
+
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: [_buildJobPlan(workflowName: 'Duplicate CI')],
+      );
+
+      expect(firstResponse.statusCode, equals(HttpStatus.ok));
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['jobs_created'], equals(0));
+      expect(body['job_ids'], isEmpty);
+      expect(body['already_completed'], isTrue);
+      final jobs = await db.select(db.buildJobs).get();
+      expect(jobs.map((job) => job.id), equals([originalJobId]));
+      expect(jobs.single.workflowName, equals('Original CI'));
+    });
+
+    test('rolls back task completion when BuildJob insertion fails', () async {
+      await _insertTask(db, status: 'processing');
+      await db.customStatement('''
+        CREATE TRIGGER reject_build_job_insert
+        BEFORE INSERT ON build_jobs
+        BEGIN
+          SELECT RAISE(ABORT, 'forced build job insertion failure');
+        END;
+      ''');
+
+      final response = await _completeTask(
+        db: db,
+        uid: 'system-job-processor',
+        jobs: [_buildJobPlan()],
+      );
+
+      expect(response.statusCode, equals(HttpStatus.internalServerError));
+      expect(await db.select(db.buildJobs).get(), isEmpty);
+      final task = await db.webhookTaskDao.getWebhookTask('task-1');
+      expect(task?.status, equals('retry_waiting'));
+      expect(task?.retryCount, equals(1));
+    });
+  });
+}
+
+Map<String, Object?> _buildJobPlan({String workflowName = 'Dashboard CI'}) {
+  return {
+    'owner': 'openci-owner',
+    'repo': 'openci-repo',
+    'workflowName': workflowName,
+    'workflowFileName': 'dashboard_ci.dart',
+    'teamId': 'team-1',
+    'commitSha': 'commit-sha-1',
+    'commitMessage': 'Add lightweight BuildJob plans',
+    'branch': 'main',
+    'runsOn': 'macos-latest',
+    'githubBaseUrl': 'https://github.com',
+    'installationId': '98765',
+  };
+}
+
+Future<void> _insertTask(
+  AppDatabase db, {
+  required String status,
+  DateTime? leaseUntil,
+  String? errorMessage,
+}) {
+  final now = DateTime.now().toUtc();
+  return db.webhookTaskDao.insertWebhookTask(
+    DriftWebhookTask(
+      id: 'task-1',
+      deliveryId: 'delivery-1',
+      eventType: 'push',
+      payload: '{}',
+      status: status,
+      leaseUntil: leaseUntil,
+      retryCount: 0,
+      errorMessage: errorMessage,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}
+
+Future<Response> _completeTask({
+  required AppDatabase db,
+  required String? uid,
+  required List<Map<String, Object?>> jobs,
+}) {
+  return _request(db: db, uid: uid, body: jsonEncode({'jobs': jobs}));
+}
+
+Future<Response> _request({
+  required AppDatabase db,
+  required String? uid,
+  required String body,
+}) async {
+  final context = TestRequestContext(
+    path: '/webhooks/tasks/task-1/complete',
+    method: HttpMethod.post,
+    body: body,
+  );
+  context.provide<AppDatabase>(db);
+  context.provide<String?>(uid);
+  return route.onRequest(context.context, 'task-1');
+}

--- a/apps/openci_server/test/routes/webhooks/tasks/fail_test.dart
+++ b/apps/openci_server/test/routes/webhooks/tasks/fail_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_dao.dart';
+import 'package:test/test.dart';
+
+import '../../../../routes/webhooks/tasks/[id]/fail.dart' as route;
+
+void main() {
+  group('POST /webhooks/tasks/[id]/fail', () {
+    late AppDatabase db;
+
+    setUp(() {
+      db = AppDatabase(NativeDatabase.memory());
+    });
+
+    tearDown(() => db.close());
+
+    test('requires the internal API identity', () async {
+      await _insertTask(db, status: 'processing');
+
+      final unauthenticated = await _failTask(db: db, uid: null);
+      final regularUser = await _failTask(db: db, uid: 'user-123');
+
+      expect(unauthenticated.statusCode, equals(HttpStatus.unauthorized));
+      expect(regularUser.statusCode, equals(HttpStatus.forbidden));
+    });
+
+    test('returns 404 when the webhook task does not exist', () async {
+      final response = await _failTask(
+        db: db,
+        uid: 'system-job-processor',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.notFound));
+    });
+
+    test('returns 400 when errorMessage is missing', () async {
+      await _insertTask(db, status: 'processing');
+
+      final response = await _request(
+        db: db,
+        uid: 'system-job-processor',
+        body: '{}',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.badRequest));
+      expect(
+        (await db.webhookTaskDao.getWebhookTask('task-1'))?.status,
+        equals('processing'),
+      );
+    });
+
+    test('moves a processing task to retry_waiting', () async {
+      await _insertTask(
+        db,
+        status: 'processing',
+        leaseUntil: DateTime.now().toUtc().add(const Duration(minutes: 5)),
+      );
+
+      final response = await _failTask(
+        db: db,
+        uid: 'system-job-processor',
+        errorMessage: 'GitHub temporarily unavailable',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      expect(body['status'], equals('retry_waiting'));
+      expect(body['retry_count'], equals(1));
+      expect(body['next_retry_at'], isNotNull);
+
+      final task = await db.webhookTaskDao.getWebhookTask('task-1');
+      expect(task?.status, equals('retry_waiting'));
+      expect(task?.retryCount, equals(1));
+      expect(task?.leaseUntil, isNull);
+      expect(task?.nextRetryAt, isNotNull);
+      expect(task?.errorMessage, equals('GitHub temporarily unavailable'));
+    });
+
+    test('moves a task to failed after retries are exhausted', () async {
+      await _insertTask(
+        db,
+        status: 'processing',
+        retryCount: webhookTaskRetryDelays.length,
+      );
+
+      final response = await _failTask(
+        db: db,
+        uid: 'system-job-processor',
+        errorMessage: 'Permanent planner failure',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final body = await response.json() as Map<String, dynamic>;
+      expect(body['status'], equals('failed'));
+      expect(body['retry_count'], equals(webhookTaskRetryDelays.length + 1));
+      expect(body['next_retry_at'], isNull);
+    });
+
+    test('does not change an already failed task again', () async {
+      await _insertTask(
+        db,
+        status: 'failed',
+        retryCount: webhookTaskRetryDelays.length + 1,
+        errorMessage: 'original failure',
+      );
+
+      final response = await _failTask(
+        db: db,
+        uid: 'system-job-processor',
+        errorMessage: 'duplicate failure',
+      );
+
+      expect(response.statusCode, equals(HttpStatus.ok));
+      final task = await db.webhookTaskDao.getWebhookTask('task-1');
+      expect(task?.retryCount, equals(webhookTaskRetryDelays.length + 1));
+      expect(task?.errorMessage, equals('original failure'));
+    });
+  });
+}
+
+Future<void> _insertTask(
+  AppDatabase db, {
+  required String status,
+  DateTime? leaseUntil,
+  int retryCount = 0,
+  String? errorMessage,
+}) {
+  final now = DateTime.now().toUtc();
+  return db.webhookTaskDao.insertWebhookTask(
+    DriftWebhookTask(
+      id: 'task-1',
+      deliveryId: 'delivery-1',
+      eventType: 'push',
+      payload: '{}',
+      status: status,
+      leaseUntil: leaseUntil,
+      retryCount: retryCount,
+      errorMessage: errorMessage,
+      createdAt: now,
+      updatedAt: now,
+    ),
+  );
+}
+
+Future<Response> _failTask({
+  required AppDatabase db,
+  required String? uid,
+  String errorMessage = 'planner failed',
+}) {
+  return _request(
+    db: db,
+    uid: uid,
+    body: jsonEncode({'errorMessage': errorMessage}),
+  );
+}
+
+Future<Response> _request({
+  required AppDatabase db,
+  required String? uid,
+  required String body,
+}) async {
+  final context = TestRequestContext(
+    path: '/webhooks/tasks/task-1/fail',
+    method: HttpMethod.post,
+    body: body,
+  );
+  context.provide<AppDatabase>(db);
+  context.provide<String?>(uid);
+  return route.onRequest(context.context, 'task-1');
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Webhookタスクの完了処理を追加しました。受信したジョブ情報を検証し、タスクを完了できます。
  - Webhookタスクの失敗記録に対応しました。エラーメッセージを保存し、リトライ回数や次回実行時刻を管理します。

- **バグ修正**
  - 完了済みタスクの再送信を安全に処理できるようになりました。
  - タスク状態の競合時に、誤った上書きが発生しないよう改善しました。
  - 不正な入力や認証エラーに対して、適切なエラー応答を返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->