### PR TITLE
feat(build-job-worker): add runWorkflow

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -3,7 +3,7 @@
 OpenCIのビルドjobを実行するDartバックエンドサービス。
 最終的にはComposeから起動する常駐プロセスとして動作させます。
 
-現在は設定の読み込み、jobを1件取得する関数、OrchardのVM準備・削除・コマンド実行、Lokiへのログ送信、ソースのcheckoutを実装しています。
+現在は設定の読み込み、jobを1件取得する関数、OrchardのVM準備・削除・コマンド実行、Lokiへのログ送信、ソースのcheckout・ワークフロー実行を実装しています。
 起動すると設定を確認して終了し、job取得関数はまだ起動処理から呼び出しません。
 そのため、起動時の外部API接続・VM操作は行いません。
 既存dispatcher/executorやComposeの起動構成も変更していません。
@@ -58,6 +58,14 @@ HTTPクライアントは呼び出し元で共有し、使用後に閉じます�
 トークンは取得時のHTTPヘッダーだけに設定し、remote URLには保存しません。スクリプトは権限`600`で配置し、実行終了時に削除します。
 `workspacePath`で配置先を変更できます。トークン取得や起動処理への組み込みはまだ行いません。
 
+`runWorkflow()`は、checkout済みのVMで`flutter pub get`と`flutter pub run genuine_ci/<workflowFileName>`を順に実行し、終了コードを返します。
+`secretsContent`はAPIと同じ`NAME=value`形式で渡し、secretsがない場合は空文字列を渡します。
+`.env`を権限`600`で上書きし、値をシェルコードとして評価せず環境変数に設定します。値の引用は不要です。
+`vmHomePath`（標準`/Users/admin`）配下の`fvm/default`をFlutterに使い、run・job IDとVM用Loki URLを設定します。
+`lokiUrl: config.internalLokiUrl`はworkerのログ送信先、`vmLokiUrl: config.lokiUrl`はVM内のワークフローの送信先です。
+stdout・stderrは`step_id: run_workflow`でLokiへ送り、送信待ちが終わってから終了コードを返します。書き込み・Orchard通信の失敗は例外、Loki送信の失敗は`onLogError`へ通知します。
+実行終了時に`.env`と実行スクリプトを削除します。secretsのAPI取得や起動処理への組み込みはまだ行いません。
+
 ## 実行
 
 リポジトリルートで`flutter pub get`を実行してから、このディレクトリで実行します。
@@ -75,6 +83,7 @@ dart run bin/main.dart
 このディレクトリで実行します。WebSocketテストはローカルのテスト用サーバーを自動起動するため、OrchardやVMの起動は不要です。
 ファイル書き込みテストはmacOSまたはLinuxの`/bin/sh`と`base64`を使い、一時ディレクトリ内で検証します。
 checkoutテストはローカルの`git`も使い、一時リポジトリで取得結果を検証します。
+ワークフローのテストは一時ディレクトリ内のテスト用Flutterコマンドで、環境変数・実行順・終了コードを検証します。
 
 ```sh
 dart format --output=none --set-exit-if-changed .

--- a/apps/build_job_worker/integration_test/run_workflow_test.dart
+++ b/apps/build_job_worker/integration_test/run_workflow_test.dart
@@ -1,0 +1,267 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build_job_worker/build_job_worker.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+class _MockOrchardApiClient extends Mock implements OrchardApiClient {}
+
+void main() {
+  late Directory temporary;
+  late String workspace;
+  late String vmHome;
+  late File records;
+  late OrchardApiClient api;
+  late http.Client lokiClient;
+  late BuildJob job;
+  late Map<String, String> environment;
+  late List<http.Request> requests;
+  const secret =
+      r'''test-only-secret 日本語 $HOME $(touch injected) `touch injected` ' " a=b''';
+  const runId = r'''run ' " $(touch injected)''';
+  const vmLokiUrl = 'http://vm-loki:3100';
+
+  Future<int> run({String secretsContent = ''}) => runWorkflow(
+    api: api,
+    lokiClient: lokiClient,
+    lokiUrl: 'http://loki:3100',
+    vmLokiUrl: vmLokiUrl,
+    vmName: 'vm-1',
+    job: job,
+    runId: runId,
+    secretsContent: secretsContent,
+    workspacePath: workspace,
+    vmHomePath: vmHome,
+    onLogError: (error, _) => fail('Unexpected Loki error: $error'),
+  );
+
+  Future<List<Map<String, dynamic>>> calls() async => [
+    for (final line in await records.readAsLines())
+      jsonDecode(line) as Map<String, dynamic>,
+  ];
+
+  setUpAll(() => registerFallbackValue((String line, String stream) {}));
+
+  setUp(() async {
+    temporary = await Directory.systemTemp.createTemp('worker-run-workflow-');
+    addTearDown(() => temporary.delete(recursive: true));
+    workspace =
+        temporary.path +
+        r'''/workspace ' " $(touch injected) `touch injected`''';
+    vmHome = '${temporary.path}/home with spaces';
+    await Directory(workspace).create();
+    final flutterBin = Directory('$vmHome/fvm/default/bin');
+    await flutterBin.create(recursive: true);
+    final recorder = File('${temporary.path}/record_flutter.dart');
+    await recorder.writeAsString(_recorderSource);
+    final flutter = File('${flutterBin.path}/flutter');
+    await flutter.writeAsString(
+      '#!/bin/sh\nexec ${_shellQuote(Platform.resolvedExecutable)} ${_shellQuote(recorder.path)} "\$@"\n',
+    );
+    expect((await Process.run('chmod', ['+x', flutter.path])).exitCode, 0);
+    records = File('${temporary.path}/calls.jsonl');
+    environment = {
+      'PATH': Platform.environment['PATH'] ?? '/usr/bin:/bin',
+      'WORKER_TEST_RECORDS': records.path,
+    };
+    final now = DateTime.utc(2026, 9, 7);
+    job = BuildJob(
+      id: r'''job ' " $(touch injected)''',
+      status: BuildJobStatus.IN_PROGRESS,
+      owner: 'acme',
+      repo: 'app',
+      workflowName: 'CI',
+      workflowFileName: r'''CI ' " $(touch injected) `touch injected`.dart''',
+      createdAt: now,
+      updatedAt: now,
+    );
+    requests = [];
+    lokiClient = MockClient((request) async {
+      requests.add(request);
+      return http.Response('', 204);
+    });
+    addTearDown(lokiClient.close);
+    api = _MockOrchardApiClient();
+    when(
+      () => api.execCommandWebSocket(
+        vmName: 'vm-1',
+        command: any(named: 'command'),
+        onLog: any(named: 'onLog'),
+      ),
+    ).thenAnswer((invocation) async {
+      final result = await Process.run(
+        '/bin/sh',
+        ['-c', invocation.namedArguments[#command] as String],
+        workingDirectory: temporary.path,
+        environment: environment,
+        includeParentEnvironment: false,
+      );
+      final onLog =
+          invocation.namedArguments[#onLog] as void Function(String, String);
+      for (final (stream, output) in [
+        ('stdout', result.stdout as String),
+        ('stderr', result.stderr as String),
+      ]) {
+        for (final line in const LineSplitter().convert(output)) {
+          onLog(line, stream);
+        }
+      }
+      return result.exitCode;
+    });
+  });
+
+  tearDown(() async {
+    expect(await File('$workspace/.env').exists(), isFalse);
+    expect(await File('$workspace.workflow.sh').exists(), isFalse);
+    expect(await File('${temporary.path}/injected').exists(), isFalse);
+    expect(await File('$workspace/injected').exists(), isFalse);
+    expect(
+      requests.map((request) => request.body).join(),
+      isNot(contains('test-only-secret')),
+    );
+  });
+
+  group('runWorkflow script', () {
+    test(
+      'loads literal secrets and runs the configured workflow after pub get',
+      () async {
+        expect(
+          await run(
+            secretsContent:
+                'WORKER_TEST_SECRET=$secret\r\n\r\nWORKER_TEST_EMPTY=\r\nWORKER_TEST_ESCAPED=first\\nsecond\nWORKER_TEST_CARRIAGE=first\rsecond\nassignment=kept',
+          ),
+          0,
+        );
+
+        final recorded = await calls();
+        expect(recorded, hasLength(2));
+        expect(recorded[0]['arguments'], ['pub', 'get']);
+        expect(recorded[1]['arguments'], [
+          'pub',
+          'run',
+          'genuine_ci/${job.workflowFileName}',
+        ]);
+        for (final call in recorded) {
+          expect(
+            call['cwd'],
+            await Directory(workspace).resolveSymbolicLinks(),
+          );
+          expect(call['envMode'], 0x180);
+          expect(call['scriptMode'], 0x180);
+          final env = call['environment'] as Map<String, dynamic>;
+          expect(env['WORKER_TEST_SECRET'], secret);
+          expect(env['WORKER_TEST_EMPTY'], '');
+          expect(env['WORKER_TEST_ESCAPED'], r'first\nsecond');
+          expect(env['WORKER_TEST_CARRIAGE'], 'first\rsecond');
+          expect(env['assignment'], 'kept');
+          expect(env['HOME'], vmHome);
+          expect(env['FLUTTER_ROOT'], '$vmHome/fvm/default');
+          expect(
+            env['PATH'],
+            startsWith(
+              '$vmHome/fvm/default/bin:$vmHome/.pub-cache/bin:/opt/homebrew/bin:/usr/local/bin:',
+            ),
+          );
+          expect(env['GENUINE_CI_RUN_ID'], runId);
+          expect(env['GENUINE_CI_BUILD_JOB_ID'], job.id);
+          expect(env['LOKI_URL'], vmLokiUrl);
+        }
+        expect(requests, isNotEmpty);
+      },
+    );
+
+    test('returns a pub get failure without starting the workflow', () async {
+      environment['WORKER_TEST_PUB_GET_EXIT'] = '17';
+
+      expect(await run(), 17);
+
+      final recorded = await calls();
+      expect(recorded.single['arguments'], ['pub', 'get']);
+    });
+
+    test('returns the workflow exit code', () async {
+      environment['WORKER_TEST_WORKFLOW_EXIT'] = '23';
+
+      expect(await run(), 23);
+
+      expect(await calls(), hasLength(2));
+    });
+
+    test('overwrites an existing env file when secrets are empty', () async {
+      await File(
+        '$workspace/.env',
+      ).writeAsString('WORKER_TEST_SECRET=test-only-secret');
+
+      expect(await run(), 0);
+
+      for (final call in await calls()) {
+        final env = call['environment'] as Map<String, dynamic>;
+        expect(env['WORKER_TEST_SECRET'], isNull);
+        expect(call['envContent'], isEmpty);
+      }
+    });
+
+    test(
+      'keeps worker settings authoritative over secrets with the same names',
+      () async {
+        expect(
+          await run(
+            secretsContent: '''HOME=/unused
+FLUTTER_ROOT=/unused
+PATH=/unused
+GENUINE_CI_RUN_ID=wrong-run
+GENUINE_CI_BUILD_JOB_ID=wrong-job
+LOKI_URL=http://wrong-loki
+''',
+          ),
+          0,
+        );
+
+        for (final call in await calls()) {
+          final env = call['environment'] as Map<String, dynamic>;
+          expect(env['HOME'], vmHome);
+          expect(env['FLUTTER_ROOT'], '$vmHome/fvm/default');
+          expect(env['GENUINE_CI_RUN_ID'], runId);
+          expect(env['GENUINE_CI_BUILD_JOB_ID'], job.id);
+          expect(env['LOKI_URL'], vmLokiUrl);
+        }
+      },
+    );
+  });
+}
+
+String _shellQuote(String value) => "'${value.replaceAll("'", "'\\''")}'";
+
+const _recorderSource = r'''
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> arguments) {
+  final env = Platform.environment;
+  final file = File(env['WORKER_TEST_RECORDS']!);
+  file.writeAsStringSync('${jsonEncode({
+    'arguments': arguments,
+    'cwd': Directory.current.path,
+    'envContent': File('.env').readAsStringSync(),
+    'envMode': File('.env').statSync().mode & 0x1ff,
+    'scriptMode': File('${Directory.current.path}.workflow.sh').statSync().mode & 0x1ff,
+    'environment': {
+      for (final key in [
+        'WORKER_TEST_SECRET', 'WORKER_TEST_EMPTY', 'WORKER_TEST_ESCAPED',
+        'WORKER_TEST_CARRIAGE', 'assignment',
+        'HOME', 'FLUTTER_ROOT', 'PATH', 'GENUINE_CI_RUN_ID',
+        'GENUINE_CI_BUILD_JOB_ID', 'LOKI_URL',
+      ]) key: env[key],
+    },
+  })}\n', mode: FileMode.append);
+  stdout.writeln('flutter ${arguments[1]} output');
+  stderr.writeln('flutter ${arguments[1]} stderr');
+  exitCode = int.parse(env[arguments[1] == 'get'
+      ? 'WORKER_TEST_PUB_GET_EXIT'
+      : 'WORKER_TEST_WORKFLOW_EXIT'] ?? '0');
+}
+''';

--- a/apps/build_job_worker/lib/build_job_worker.dart
+++ b/apps/build_job_worker/lib/build_job_worker.dart
@@ -6,3 +6,4 @@ export 'src/orchard/execute_command.dart';
 export 'src/orchard/orchard_api_client.dart';
 export 'src/orchard/prepare_vm.dart';
 export 'src/orchard/write_file.dart';
+export 'src/run_workflow.dart';

--- a/apps/build_job_worker/lib/src/run_workflow.dart
+++ b/apps/build_job_worker/lib/src/run_workflow.dart
@@ -1,0 +1,107 @@
+import 'package:http/http.dart' as http;
+import 'package:openci_shared/openci_shared.dart';
+
+import 'orchard/execute_command.dart';
+import 'orchard/orchard_api_client.dart';
+import 'orchard/write_file.dart';
+
+Future<int> runWorkflow({
+  required OrchardApiClient api,
+  required http.Client lokiClient,
+  required String lokiUrl,
+  required String vmLokiUrl,
+  required String vmName,
+  required BuildJob job,
+  required String runId,
+  required String secretsContent,
+  required void Function(Object error, StackTrace stackTrace) onLogError,
+  String workspacePath = '/tmp/workspace',
+  String vmHomePath = '/Users/admin',
+}) async {
+  final workspace = workspacePath.replaceFirst(RegExp(r'/+$'), '');
+  final vmHome = vmHomePath.replaceFirst(RegExp(r'/+$'), '');
+  if ([
+    workspace,
+    vmHome,
+  ].any((path) => !path.startsWith('/') || path.contains('\u0000'))) {
+    throw ArgumentError(
+      'workspacePath and vmHomePath must be absolute paths without NUL.',
+    );
+  }
+  final fileName = job.workflowFileName;
+  if (fileName.isEmpty ||
+      fileName.startsWith('/') ||
+      fileName.split('/').contains('..') ||
+      fileName.contains('\u0000')) {
+    throw ArgumentError(
+      'workflowFileName must be a relative path within genuine_ci.',
+    );
+  }
+  if ([
+    runId,
+    job.id,
+    vmLokiUrl,
+  ].any((value) => value.isEmpty || value.contains('\u0000'))) {
+    throw ArgumentError(
+      'Run ID, job ID, and VM Loki URL must not be empty or contain NUL.',
+    );
+  }
+  final assignments = secretsContent
+      .replaceAll('\r\n', '\n')
+      .split('\n')
+      .where((line) => line.isNotEmpty)
+      .toList();
+  if (secretsContent.contains('\u0000') ||
+      assignments.any(
+        (line) => !RegExp(r'^[A-Za-z_][A-Za-z0-9_]*=').hasMatch(line),
+      )) {
+    throw ArgumentError(
+      'secretsContent must contain NAME=value lines without NUL.',
+    );
+  }
+
+  final envPath = '$workspace/.env';
+  final scriptPath = '$workspace.workflow.sh';
+  final script =
+      '''
+set -e
+trap ${_shellQuote('/bin/rm -f -- ${_shellQuote(scriptPath)} ${_shellQuote(envPath)}')} 0
+cd ${_shellQuote(workspace)}
+${assignments.map((line) => 'export ${_shellQuote(line)}').join('\n')}
+export HOME=${_shellQuote(vmHome)}
+export FLUTTER_ROOT=${_shellQuote('$vmHome/fvm/default')}
+export PATH="\$FLUTTER_ROOT/bin:\$HOME/.pub-cache/bin:/opt/homebrew/bin:/usr/local/bin:\$PATH"
+export GENUINE_CI_RUN_ID=${_shellQuote(runId)}
+export GENUINE_CI_BUILD_JOB_ID=${_shellQuote(job.id)}
+export LOKI_URL=${_shellQuote(vmLokiUrl)}
+flutter pub get
+flutter pub run ${_shellQuote('genuine_ci/$fileName')}
+''';
+  await writeFile(
+    api: api,
+    vmName: vmName,
+    filePath: envPath,
+    content: assignments.join('\n'),
+    mode: '600',
+  );
+  await writeFile(
+    api: api,
+    vmName: vmName,
+    filePath: scriptPath,
+    content: script,
+    mode: '600',
+  );
+  return executeCommand(
+    api: api,
+    lokiClient: lokiClient,
+    lokiUrl: lokiUrl,
+    vmName: vmName,
+    command: '/bin/sh ${_shellQuote(scriptPath)}',
+    runId: runId,
+    jobId: job.id,
+    stepId: 'run_workflow',
+    onLogError: onLogError,
+  );
+}
+
+String _shellQuote(String value) => "'${value.replaceAll("'", "'\\''")}'";

--- a/apps/build_job_worker/test/src/run_workflow_test.dart
+++ b/apps/build_job_worker/test/src/run_workflow_test.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+
+import 'package:build_job_worker/build_job_worker.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+class _MockOrchardApiClient extends Mock implements OrchardApiClient {}
+
+void main() {
+  late OrchardApiClient api;
+  late http.Client lokiClient;
+  late BuildJob job;
+  late List<String> commands;
+  late List<http.Request> requests;
+  late List<Object> logErrors;
+  int? failedWrite;
+  var workflowExitCode = 0;
+  var lokiStatusCode = 204;
+  Object? executionError;
+
+  Future<int> run({
+    String secretsContent = 'WORKER_TEST_SECRET=test-only-value',
+    String workspacePath = '/tmp/workspace',
+    String vmHomePath = '/Users/admin',
+    String runId = 'run-1',
+  }) => runWorkflow(
+    api: api,
+    lokiClient: lokiClient,
+    lokiUrl: 'http://loki:3100',
+    vmLokiUrl: 'http://vm-loki:3100',
+    vmName: 'vm-1',
+    job: job,
+    runId: runId,
+    secretsContent: secretsContent,
+    workspacePath: workspacePath,
+    vmHomePath: vmHomePath,
+    onLogError: (error, _) => logErrors.add(error),
+  );
+
+  setUpAll(() => registerFallbackValue((String line, String stream) {}));
+
+  setUp(() {
+    api = _MockOrchardApiClient();
+    commands = [];
+    requests = [];
+    logErrors = [];
+    failedWrite = null;
+    workflowExitCode = 0;
+    lokiStatusCode = 204;
+    executionError = null;
+    final now = DateTime.utc(2026, 9, 7);
+    job = BuildJob(
+      id: 'job-1',
+      status: BuildJobStatus.IN_PROGRESS,
+      owner: 'acme',
+      repo: 'app',
+      workflowName: 'CI',
+      workflowFileName: 'ci.dart',
+      createdAt: now,
+      updatedAt: now,
+    );
+    lokiClient = MockClient((request) async {
+      requests.add(request);
+      return http.Response('', lokiStatusCode);
+    });
+    when(
+      () => api.execCommandWebSocket(
+        vmName: 'vm-1',
+        command: any(named: 'command'),
+        onLog: any(named: 'onLog'),
+      ),
+    ).thenAnswer((invocation) async {
+      commands.add(invocation.namedArguments[#command] as String);
+      final onLog =
+          invocation.namedArguments[#onLog] as void Function(String, String);
+      if (commands.length <= 2) {
+        onLog('WORKER_TEST_SECRET=test-only-value', 'stdout');
+        return commands.length == failedWrite ? 1 : 0;
+      }
+      onLog('workflow output', 'stdout');
+      onLog('workflow error output', 'stderr');
+      if (executionError != null) throw executionError!;
+      return workflowExitCode;
+    });
+  });
+
+  tearDown(() {
+    verifyNever(api.close);
+    lokiClient.close();
+  });
+
+  group('runWorkflow', () {
+    for (final exitCode in [0, 23]) {
+      test(
+        'returns exit code $exitCode after forwarding workflow logs',
+        () async {
+          workflowExitCode = exitCode;
+
+          expect(await run(), exitCode);
+
+          expect(commands, hasLength(3));
+          expect(requests, hasLength(2));
+          for (final (index, stream) in ['stdout', 'stderr'].indexed) {
+            expect(
+              requests[index].url.toString(),
+              'http://loki:3100/loki/api/v1/push',
+            );
+            final body =
+                jsonDecode(requests[index].body) as Map<String, dynamic>;
+            final entry =
+                (body['streams'] as List<dynamic>).single
+                    as Map<String, dynamic>;
+            expect(entry['stream'], {
+              'stream': stream,
+              'type': 'step_log',
+              'run_id': 'run-1',
+              'build_job_id': 'job-1',
+              'step_id': 'run_workflow',
+            });
+          }
+          expect(
+            requests.map((request) => request.body).join(),
+            isNot(contains('test-only-value')),
+          );
+          expect(logErrors, isEmpty);
+        },
+      );
+    }
+
+    for (final writeNumber in [1, 2]) {
+      test(
+        'stops before execution when file write $writeNumber fails',
+        () async {
+          failedWrite = writeNumber;
+
+          await expectLater(run(), throwsStateError);
+
+          expect(commands, hasLength(writeNumber));
+          expect(requests, isEmpty);
+        },
+      );
+    }
+
+    test('propagates execution errors after forwarding pending logs', () async {
+      executionError = StateError('Orchard connection closed before exit');
+
+      await expectLater(run(), throwsA(same(executionError)));
+
+      expect(requests, hasLength(2));
+    });
+
+    test('reports Loki errors and preserves the workflow exit code', () async {
+      lokiStatusCode = 500;
+      workflowExitCode = 42;
+
+      expect(await run(), 42);
+
+      expect(logErrors, hasLength(2));
+      expect(requests, hasLength(2));
+    });
+
+    for (final invalidSecrets in [
+      'test-only-value',
+      'BAD-KEY=test-only-value',
+      'KEY=test-only-value\nnot-an-assignment',
+      'KEY=test-only-value\u0000',
+    ]) {
+      test('rejects invalid secrets without exposing their content', () async {
+        await expectLater(
+          run(secretsContent: invalidSecrets),
+          throwsA(
+            isA<ArgumentError>().having(
+              (error) => error.toString(),
+              'message',
+              isNot(contains('test-only-value')),
+            ),
+          ),
+        );
+
+        verifyZeroInteractions(api);
+      });
+    }
+
+    for (final name in ['', '../ci.dart', '/ci.dart', 'ci\u0000.dart']) {
+      test(
+        'rejects an invalid workflow path before contacting Orchard',
+        () async {
+          job = job.copyWith(workflowFileName: name);
+
+          await expectLater(run(), throwsArgumentError);
+
+          verifyZeroInteractions(api);
+        },
+      );
+    }
+
+    test('rejects invalid VM paths before contacting Orchard', () async {
+      await expectLater(run(workspacePath: '/'), throwsArgumentError);
+      await expectLater(run(vmHomePath: 'relative'), throwsArgumentError);
+      await expectLater(
+        run(workspacePath: '/tmp/work\u0000space'),
+        throwsArgumentError,
+      );
+      verifyZeroInteractions(api);
+    });
+
+    test('rejects invalid run IDs before contacting Orchard', () async {
+      await expectLater(run(runId: ''), throwsArgumentError);
+      await expectLater(run(runId: 'run\u0000id'), throwsArgumentError);
+      verifyZeroInteractions(api);
+    });
+  });
+}


### PR DESCRIPTION
checkout済みのOrchard VMで `flutter pub get` → `flutter pub run genuine_ci/<workflowFileName>` を実行する `runWorkflow()` を追加します。`pub get` が失敗した場合はワークフローを起動せず、終了コードを呼び出し元へ返します。

引数のsecretsと実行スクリプトを権限 `600` で配置し、値を文字列として環境変数に設定します。FlutterのPATH、run・job ID、VM用Loki URLを設定し、stdout・stderrを `run_workflow` ステップのログとしてLokiへ送ります。スクリプト終了時に `.env` と実行スクリプトを削除します。

変更はworker内の関数・公開export・テスト・READMEの5ファイルです。secretsのAPI取得と起動処理への接続は後続作業です。

検証（Flutter 3.44.8 / Dart 3.12.2）：

- フォーマットチェック、`flutter analyze --no-pub .`、`git diff --check` が通過。
- `flutter test --coverage --no-pub`：89件通過。
- `dart test integration_test`：38件通過。
- テスト用Flutterコマンドで実行順、終了コード、secretsの文字列保持、権限、後片付けを検証。実VMでのビルド確認は未実施です。
