### PR TITLE
Add integration tests for PostgreSQL and enhance GitHub service tests

### DIFF
--- a/.github/workflows/dart-apps-ci.yml
+++ b/.github/workflows/dart-apps-ci.yml
@@ -43,9 +43,25 @@ jobs:
               apps/openci_server/lib
               apps/openci_server/routes
               apps/openci_server/test
+              apps/openci_server/integration_test
           - app: openci_shared
             path: packages/openci_shared
             format_paths: packages/openci_shared
+
+    services:
+      postgres:
+        image: ${{ matrix.app == 'openci_server' && 'postgres:16-alpine' || '' }}
+        env:
+          POSTGRES_DB: openci_test
+          POSTGRES_USER: openci_test
+          POSTGRES_PASSWORD: openci_test
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd "pg_isready -U openci_test -d openci_test"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 10
 
     steps:
       - name: Checkout repository
@@ -73,8 +89,18 @@ jobs:
         run: flutter analyze --no-pub ${{ matrix.path }}
 
       - name: Run unit tests with coverage
+        if: matrix.app != 'openci_server'
         working-directory: ${{ matrix.path }}
         run: flutter test --coverage --no-pub
+
+      - name: Run server tests with lib and routes coverage
+        if: matrix.app == 'openci_server'
+        working-directory: ${{ matrix.path }}
+        env:
+          TEST_DATABASE_URL: postgres://openci_test:openci_test@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/openci_test?sslmode=disable
+        run: |
+          dart test test integration_test --coverage=coverage/raw
+          dart run coverage:format_coverage --lcov --in=coverage/raw --out=coverage/lcov.info --report-on=lib --report-on=routes --base-directory=.
 
       - name: Run worker startup tests
         if: matrix.app == 'build_job_worker'

--- a/apps/openci_server/integration_test/README.md
+++ b/apps/openci_server/integration_test/README.md
@@ -1,0 +1,39 @@
+# PostgreSQL tests
+
+These tests use PostgreSQL 16, matching `docker-compose.yml`. Each test creates
+and removes its own schema. Use a disposable database with permission to create
+schemas.
+
+Start a local test database (the password below is only a test fixture):
+
+```sh
+docker run --detach --rm --name openci-server-test-db \
+  --env POSTGRES_DB=openci_test \
+  --env POSTGRES_USER=openci_test \
+  --env POSTGRES_PASSWORD=openci_test \
+  --publish 127.0.0.1:55432:5432 postgres:16-alpine
+docker exec openci-server-test-db pg_isready -U openci_test -d openci_test
+```
+
+After PostgreSQL reports that it accepts connections, run from
+`apps/openci_server`:
+
+```sh
+export TEST_DATABASE_URL='postgres://openci_test:openci_test@127.0.0.1:55432/openci_test?sslmode=disable'
+dart test integration_test
+```
+
+To collect unit and integration coverage, including Dart Frog's `routes/`, use
+the same commands as CI:
+
+```sh
+rm -rf coverage/raw
+dart test test integration_test --coverage=coverage/raw
+dart run coverage:format_coverage --lcov --in=coverage/raw --out=coverage/lcov.info --report-on=lib --report-on=routes --base-directory=.
+```
+
+Stop the disposable database when finished:
+
+```sh
+docker stop openci-server-test-db
+```

--- a/apps/openci_server/integration_test/build_job_claim_test.dart
+++ b/apps/openci_server/integration_test/build_job_claim_test.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show driftRuntimeOptions;
+import 'package:drift_postgres/drift_postgres.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:postgres/postgres.dart' as pg;
+import 'package:test/test.dart';
+
+void main() {
+  final databaseUrl = Platform.environment['TEST_DATABASE_URL'];
+  if (databaseUrl == null || databaseUrl.isEmpty) {
+    throw StateError('Set TEST_DATABASE_URL to run the PostgreSQL tests.');
+  }
+
+  late pg.Connection admin;
+  late String schema;
+  late AppDatabase db;
+
+  setUpAll(() {
+    // Each worker deliberately uses its own PostgreSQL connection.
+    final previous = driftRuntimeOptions.dontWarnAboutMultipleDatabases;
+    driftRuntimeOptions.dontWarnAboutMultipleDatabases = true;
+    addTearDown(
+      () => driftRuntimeOptions.dontWarnAboutMultipleDatabases = previous,
+    );
+  });
+
+  Future<AppDatabase> openDatabase() async {
+    final connection = await pg.Connection.openFromUrl(databaseUrl);
+    addTearDown(connection.close);
+    await connection.execute('SET search_path TO "$schema"');
+    final database = AppDatabase(PgDatabase.opened(connection));
+    addTearDown(database.close);
+    await database.customSelect('SELECT 1').get();
+    return database;
+  }
+
+  setUp(() async {
+    admin = await pg.Connection.openFromUrl(databaseUrl);
+    addTearDown(admin.close);
+    schema = 'claim_test_${DateTime.now().microsecondsSinceEpoch}';
+    await admin.execute('CREATE SCHEMA "$schema"');
+    addTearDown(() => admin.execute('DROP SCHEMA "$schema" CASCADE'));
+    await admin.execute('SET search_path TO "$schema"');
+    db = await openDatabase();
+  });
+
+  group('BuildJobDao.claimNextJob on PostgreSQL', () {
+    test('returns null when no jobs are queued', () async {
+      expect(await db.buildJobDao.claimNextJob(), isNull);
+      for (final status in BuildJobStatus.values.where(
+        (s) => s != BuildJobStatus.QUEUED,
+      )) {
+        await db.buildJobDao.insertBuildJob(_job(status.name, status: status));
+      }
+
+      expect(await db.buildJobDao.claimNextJob(), isNull);
+    });
+
+    test('claims the oldest job and persists the worker assignment', () async {
+      final oldest = _job('oldest');
+      await db.buildJobDao.insertBuildJob(_job('newer', minute: 1));
+      await db.buildJobDao.insertBuildJob(oldest);
+      final before = DateTime.now().toUtc();
+
+      final claimed = (await db.buildJobDao.claimNextJob(
+        vmName: 'vm-a',
+        workerHost: 'host-a',
+      ))!;
+
+      expect(claimed.id, 'oldest');
+      expect(claimed.status, BuildJobStatus.IN_PROGRESS);
+      expect(claimed.vmName, 'vm-a');
+      expect(claimed.workerHost, 'host-a');
+      expect(claimed.createdAt.toUtc(), oldest.createdAt);
+      expect(claimed.updatedAt.isBefore(before), isFalse);
+      final stored = (await db.buildJobDao.getBuildJob('oldest'))!;
+      expect(stored.status, claimed.status);
+      expect(stored.vmName, claimed.vmName);
+      expect(stored.workerHost, claimed.workerHost);
+      expect((await db.buildJobDao.getQueuedJobs()).single.id, 'newer');
+    });
+
+    test('counts only active jobs assigned to the requested host', () async {
+      await db.buildJobDao.insertBuildJob(
+        _job(
+          'active',
+          status: BuildJobStatus.IN_PROGRESS,
+          workerHost: 'host-a',
+        ),
+      );
+      await db.buildJobDao.insertBuildJob(
+        _job('completed', status: BuildJobStatus.SUCCESS, workerHost: 'host-b'),
+      );
+      await db.buildJobDao.insertBuildJob(_job('queued'));
+
+      expect(
+        await db.buildJobDao.claimNextJob(
+          workerHost: 'host-a',
+          maxConcurrentJobs: 1,
+        ),
+        isNull,
+      );
+      expect(
+        (await db.buildJobDao.getBuildJob('queued'))!.status,
+        BuildJobStatus.QUEUED,
+      );
+      expect(
+        (await db.buildJobDao.claimNextJob(
+          workerHost: 'host-b',
+          maxConcurrentJobs: 1,
+        ))?.id,
+        'queued',
+      );
+    });
+
+    test('claims without a host or concurrency limit', () async {
+      await db.buildJobDao.insertBuildJob(_job('queued'));
+
+      final claimed = (await db.buildJobDao.claimNextJob())!;
+
+      expect(claimed.id, 'queued');
+      expect(claimed.vmName, isNull);
+      expect(claimed.workerHost, isNull);
+      expect(await db.buildJobDao.claimNextJob(), isNull);
+    });
+
+    test('skips a locked job and leaves it available after rollback', () async {
+      await db.buildJobDao.insertBuildJob(_job('locked'));
+      await db.buildJobDao.insertBuildJob(_job('available', minute: 1));
+      await admin.execute('BEGIN');
+      try {
+        await admin.execute(
+          "SELECT * FROM build_jobs WHERE id = 'locked' FOR UPDATE",
+        );
+
+        expect((await db.buildJobDao.claimNextJob())?.id, 'available');
+        expect(await db.buildJobDao.claimNextJob(), isNull);
+      } finally {
+        await admin.execute('ROLLBACK');
+      }
+
+      expect((await db.buildJobDao.claimNextJob())?.id, 'locked');
+    });
+
+    test('independent workers cannot claim the same job', () async {
+      await db.buildJobDao.insertBuildJob(_job('only-job'));
+      final other = await openDatabase();
+
+      final results = await Future.wait([
+        db.buildJobDao.claimNextJob(workerHost: 'host-a'),
+        other.buildJobDao.claimNextJob(workerHost: 'host-b'),
+      ]);
+
+      expect(results.whereType<DriftBuildJob>().map((job) => job.id), [
+        'only-job',
+      ]);
+      expect(results.where((job) => job == null), hasLength(1));
+      expect(
+        (await db.buildJobDao.getBuildJob('only-job'))!.status,
+        BuildJobStatus.IN_PROGRESS,
+      );
+    });
+
+    test(
+      'simultaneous claims respect the concurrency limit for one host',
+      () async {
+        await db.buildJobDao.insertBuildJob(_job('first'));
+        await db.buildJobDao.insertBuildJob(_job('second', minute: 1));
+        final other = await openDatabase();
+        final workerPids = [
+          (await db.customSelect('SELECT pg_backend_pid() AS pid').getSingle())
+              .read<int>('pid'),
+          (await other
+                  .customSelect('SELECT pg_backend_pid() AS pid')
+                  .getSingle())
+              .read<int>('pid'),
+        ];
+
+        // Hold updates until both claim transactions have reached a lock. This
+        // reproduces overlapping claims without relying on scheduler timing.
+        final gate = DateTime.now().microsecondsSinceEpoch;
+        await admin.execute('''
+        CREATE FUNCTION hold_claim_update() RETURNS trigger AS \$\$
+        BEGIN
+          PERFORM pg_advisory_xact_lock($gate);
+          RETURN NEW;
+        END;
+        \$\$ LANGUAGE plpgsql
+      ''');
+        await admin.execute('''
+        CREATE TRIGGER hold_claim_update BEFORE UPDATE ON build_jobs
+        FOR EACH ROW EXECUTE FUNCTION hold_claim_update()
+      ''');
+        await admin.execute('SELECT pg_advisory_lock($gate)');
+        final claims = Future.wait([
+          db.buildJobDao.claimNextJob(
+            workerHost: 'shared-host',
+            maxConcurrentJobs: 1,
+          ),
+          other.buildJobDao.claimNextJob(
+            workerHost: 'shared-host',
+            maxConcurrentJobs: 1,
+          ),
+        ]);
+        // Register a listener immediately so setup failures cannot leave an
+        // unhandled asynchronous error while the gate is being released.
+        unawaited(
+          claims.then<void>((_) {}, onError: (Object _, StackTrace _) {}),
+        );
+        try {
+          await _waitForBlockedWorkers(admin, workerPids);
+        } finally {
+          await admin.execute('SELECT pg_advisory_unlock($gate)');
+        }
+
+        final results = await claims;
+        expect(results.whereType<DriftBuildJob>(), hasLength(1));
+        expect((await db.buildJobDao.getQueuedJobs()).map((job) => job.id), [
+          'second',
+        ]);
+      },
+    );
+  });
+}
+
+Future<void> _waitForBlockedWorkers(pg.Connection admin, List<int> pids) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 5));
+  while (DateTime.now().isBefore(deadline)) {
+    final result = await admin.execute('''
+      SELECT COUNT(*) FROM pg_stat_activity
+      WHERE pid IN (${pids.join(',')}) AND wait_event_type = 'Lock'
+    ''');
+    if (result.single.single == pids.length) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('Both claim transactions did not reach a lock in time.');
+}
+
+DriftBuildJob _job(
+  String id, {
+  BuildJobStatus status = BuildJobStatus.QUEUED,
+  String? workerHost,
+  int minute = 0,
+}) => DriftBuildJob(
+  id: id,
+  status: status,
+  owner: 'openci-org',
+  repo: 'openci',
+  workflowName: 'CI',
+  workflowFileName: 'ci.dart',
+  workerHost: workerHost,
+  createdAt: DateTime.utc(2026, 9, 1, 0, minute),
+  updatedAt: DateTime.utc(2026, 9, 1, 0, minute),
+);

--- a/apps/openci_server/lib/build_job/build_job_dao.dart
+++ b/apps/openci_server/lib/build_job/build_job_dao.dart
@@ -17,6 +17,14 @@ class BuildJobDao extends DatabaseAccessor<AppDatabase>
   }) async {
     return db.transaction(() async {
       if (maxConcurrentJobs != null && workerHost != null) {
+        // Serialize the count and claim for this host across server instances.
+        await db
+            .customSelect(
+              r"SELECT pg_advisory_xact_lock(hashtext('build_job_claim'), hashtext($1))",
+              variables: [Variable.withString(workerHost)],
+            )
+            .get();
+
         final countExpr = buildJobs.id.count();
         final activeCount =
             await (selectOnly(buildJobs)

--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -383,14 +383,30 @@ Future<void> main() async {
       endpoint: githubApiBaseUrl,
       client: client,
     );
-    final slug = RepositorySlug(owner, repo);
+    Future<RepositoryContents> getContents(String path) {
+      // getContents in github.dart does not validate the HTTP status. Require
+      // 200 here so a missing directory is reported as NotFound.
+      return github.getJSON<dynamic, RepositoryContents>(
+        '/repos/$owner/$repo/contents/$path',
+        statusCode: HttpStatus.ok,
+        params: {'ref': commitSha},
+        convert: (data) => data is List
+            ? RepositoryContents(
+                tree: data
+                    .map(
+                      (item) =>
+                          GitHubFile.fromJson(item as Map<String, dynamic>),
+                    )
+                    .toList(),
+              )
+            : RepositoryContents(
+                file: GitHubFile.fromJson(data as Map<String, dynamic>),
+              ),
+      );
+    }
 
     try {
-      final contents = await github.repositories.getContents(
-        slug,
-        'genuine_ci',
-        ref: commitSha,
-      );
+      final contents = await getContents('genuine_ci');
 
       final files = <GenuineCiFile>[];
       if (contents.isDirectory && contents.tree != null) {
@@ -401,11 +417,7 @@ Future<void> main() async {
           if (fileName != null &&
               filePath != null &&
               fileName.endsWith('.dart')) {
-            final fileContents = await github.repositories.getContents(
-              slug,
-              filePath,
-              ref: commitSha,
-            );
+            final fileContents = await getContents(filePath);
             final text = fileContents.file?.text;
             if (text != null) {
               files.add(

--- a/apps/openci_server/pubspec.yaml
+++ b/apps/openci_server/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.15.0
+  coverage: ^1.15.1
   dart_frog_test: ^0.1.2
   drift_dev: ^2.33.0
   mockito: ^5.4.4

--- a/apps/openci_server/test/build_job/build_job_mapper_test.dart
+++ b/apps/openci_server/test/build_job/build_job_mapper_test.dart
@@ -1,0 +1,180 @@
+import 'package:openci_server/build_job/build_job_mapper.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('groupBuildJobsToCommitGroups', () {
+    test('returns no groups for an empty job list', () {
+      expect(groupBuildJobsToCommitGroups([]), isEmpty);
+    });
+
+    test('supplies fallbacks for missing commit metadata', () {
+      final group = groupBuildJobsToCommitGroups([_job('build')]).single;
+
+      expect(group.commitSha, 'unknown');
+      expect(group.branch, 'unknown');
+      expect(group.commitMessage, 'openci-org/openci on unknown');
+    });
+
+    test('uses available metadata and sorts commits by their newest job', () {
+      final groups = groupBuildJobsToCommitGroups([
+        _job('old').copyWith(commitSha: 'sha-a'),
+        _job('middle').copyWith(
+          commitSha: 'sha-b',
+          createdAt: DateTime.utc(2026, 9, 2),
+        ),
+        _job('new').copyWith(
+          commitSha: 'sha-a',
+          branch: 'develop',
+          commitMessage: 'Add tests',
+          workflowFileName: 'release.dart',
+          createdAt: DateTime.utc(2026, 9, 3),
+        ),
+      ]);
+
+      expect(groups.map((group) => group.commitSha), ['sha-a', 'sha-b']);
+      expect(groups.first.createdAt, DateTime.utc(2026, 9, 3));
+      expect(groups.first.branch, 'develop');
+      expect(groups.first.commitMessage, 'Add tests');
+      expect(
+        groups.first.workflows.map((workflow) => workflow.fileName),
+        ['ci.dart', 'release.dart'],
+      );
+    });
+
+    for (final status in [
+      BuildJobStatus.QUEUED,
+      BuildJobStatus.WAITING,
+      BuildJobStatus.IN_PROGRESS,
+    ]) {
+      test('$status keeps workflow and commit in progress', () {
+        final group = groupBuildJobsToCommitGroups([
+          _job('done'),
+          _job('pending').copyWith(status: status),
+        ]).single;
+
+        expect(group.status, BuildJobStatus.IN_PROGRESS);
+        expect(group.workflows.single.status, BuildJobStatus.IN_PROGRESS);
+      });
+    }
+
+    for (final status in [
+      BuildJobStatus.FAILURE,
+      BuildJobStatus.CANCELLED,
+      BuildJobStatus.TIMED_OUT,
+    ]) {
+      test('$status takes precedence over running and successful work', () {
+        final group = groupBuildJobsToCommitGroups([
+          _job('done'),
+          _job('running').copyWith(status: BuildJobStatus.IN_PROGRESS),
+          _job('failed').copyWith(status: status),
+          _job('other-workflow').copyWith(workflowFileName: 'release.dart'),
+        ]).single;
+
+        expect(group.status, BuildJobStatus.FAILURE);
+        expect(group.workflows.first.status, BuildJobStatus.FAILURE);
+        expect(group.workflows.last.status, BuildJobStatus.SUCCESS);
+      });
+    }
+
+    test('uses the longest completed job duration, not their sum', () {
+      final group = groupBuildJobsToCommitGroups([
+        _job('short').copyWith(completedAt: DateTime.utc(2026, 9, 1, 0, 1)),
+        _job('long').copyWith(completedAt: DateTime.utc(2026, 9, 1, 0, 3)),
+        _job('skipped').copyWith(status: BuildJobStatus.SKIPPED),
+      ]).single;
+
+      expect(group.status, BuildJobStatus.SUCCESS);
+      expect(group.workflows.single.duration, const Duration(minutes: 3));
+    });
+
+    for (final status in [BuildJobStatus.IN_PROGRESS, BuildJobStatus.QUEUED]) {
+      test('includes elapsed time for an unfinished $status job', () {
+        final before = DateTime.now().toUtc();
+        final createdAt = before.subtract(const Duration(minutes: 2));
+        final group = groupBuildJobsToCommitGroups([
+          _job('active').copyWith(status: status, createdAt: createdAt),
+        ]).single;
+        final after = DateTime.now().toUtc();
+
+        expect(
+          group.workflows.single.duration.inMicroseconds,
+          inInclusiveRange(
+            before.difference(createdAt).inMicroseconds,
+            after.difference(createdAt).inMicroseconds,
+          ),
+        );
+      });
+    }
+  });
+
+  group('partitionJobsIntoStages', () {
+    test('returns no stages for an empty job list', () {
+      expect(partitionJobsIntoStages([]), isEmpty);
+    });
+
+    test(
+      'orders dependencies regardless of input order and ignores absent jobs',
+      () {
+        final stages = partitionJobsIntoStages([
+          _job('deploy').copyWith(needs: ['test']),
+          _job('test').copyWith(needs: ['build']),
+          _job('build').copyWith(needs: ['external-job']),
+          _job('lint'),
+        ]);
+
+        expect(stages.map((stage) => stage.map((job) => job.id)), [
+          ['build', 'lint'],
+          ['test'],
+          ['deploy'],
+        ]);
+      },
+    );
+
+    test('keeps cyclic dependencies in a final stage without losing jobs', () {
+      final stages = partitionJobsIntoStages([
+        _job('a').copyWith(needs: ['b'], matrixLabel: 'iOS'),
+        _job('b').copyWith(needs: ['a']),
+        _job('independent'),
+      ]);
+
+      expect(stages.map((stage) => stage.map((job) => job.id)), [
+        ['independent'],
+        ['a', 'b'],
+      ]);
+      expect(stages.last.map((job) => job.label), ['iOS', 'b']);
+    });
+
+    test('preserves matrix job labels and falls back to the job ID', () {
+      final stages = partitionJobsIntoStages([
+        _job('ios').copyWith(jobKey: 'build-ios', matrix: {'os': 'ios'}),
+        _job(
+          'android',
+        ).copyWith(jobKey: 'build-android', matrixLabel: 'Android'),
+        _job('plain').copyWith(jobKey: null),
+      ]);
+
+      expect(stages.single.map((job) => job.label), [
+        'ios',
+        'Android',
+        'plain',
+      ]);
+      expect(
+        stages.single.map((job) => job.status),
+        everyElement(BuildJobStatus.SUCCESS),
+      );
+    });
+  });
+}
+
+BuildJob _job(String id) => BuildJob(
+  id: id,
+  jobKey: id,
+  status: BuildJobStatus.SUCCESS,
+  owner: 'openci-org',
+  repo: 'openci',
+  workflowName: 'CI',
+  workflowFileName: 'ci.dart',
+  createdAt: DateTime.utc(2026, 9, 1),
+  updatedAt: DateTime.utc(2026, 9, 1),
+);

--- a/apps/openci_server/test/db/build_job_dao_test.dart
+++ b/apps/openci_server/test/db/build_job_dao_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:openci_server/build_job/build_job_dao.dart';
 import 'package:openci_server/database.dart';
@@ -19,6 +20,227 @@ void main() {
     tearDown(() async {
       await db.close();
     });
+
+    test(
+      'successful macOS queries filter jobs and sort by completion time',
+      () async {
+        final old = _job('old').copyWith(
+          status: BuildJobStatus.SUCCESS,
+          branch: const Value('develop'),
+          runsOn: const Value('macos-latest'),
+          completedAt: Value(DateTime.utc(2026, 9, 1, 0, 1)),
+        );
+        final latest = old.copyWith(
+          id: 'latest',
+          createdAt: old.createdAt.subtract(const Duration(hours: 1)),
+          completedAt: Value(DateTime.utc(2026, 9, 1, 0, 2)),
+        );
+        for (final job in [
+          latest,
+          old,
+          latest.copyWith(id: 'wrong-owner', owner: 'other'),
+          latest.copyWith(id: 'wrong-repo', repo: 'other'),
+          latest.copyWith(id: 'failed', status: BuildJobStatus.FAILURE),
+          latest.copyWith(id: 'linux', runsOn: const Value('ubuntu-latest')),
+          latest.copyWith(id: 'main', branch: const Value('main')),
+          latest.copyWith(id: 'no-runner', runsOn: const Value(null)),
+        ]) {
+          await dao.insertBuildJob(job);
+        }
+
+        expect(
+          (await dao.getLatestSuccessfulMacosJob(
+            owner: 'openci-org',
+            repo: 'openci',
+          ))?.id,
+          'latest',
+        );
+        expect(
+          (await dao.getRecentSuccessfulMacosJobs(
+            owner: 'openci-org',
+            repo: 'openci',
+          )).map((job) => job.id),
+          ['latest', 'old'],
+        );
+        expect(
+          (await dao.getRecentSuccessfulMacosJobs(
+            owner: 'openci-org',
+            repo: 'openci',
+            limit: 1,
+          )).map((job) => job.id),
+          ['latest'],
+        );
+        expect(
+          await dao.getLatestSuccessfulMacosJob(
+            owner: 'missing',
+            repo: 'openci',
+          ),
+          isNull,
+        );
+        expect(
+          await dao.getRecentSuccessfulMacosJobs(
+            owner: 'missing',
+            repo: 'openci',
+          ),
+          isEmpty,
+        );
+      },
+    );
+
+    test('team queries apply IPA filters and limits after sorting', () async {
+      for (final job in [
+        _job('ipa').copyWith(hasIpa: const Value(true)),
+        _job('no-ipa').copyWith(
+          hasIpa: const Value(false),
+          createdAt: DateTime.utc(2026, 9, 2),
+        ),
+        _job('unknown-ipa').copyWith(createdAt: DateTime.utc(2026, 9, 3)),
+        _job('other-team').copyWith(teamId: const Value('other-team')),
+      ]) {
+        await dao.insertBuildJob(job);
+      }
+
+      expect(
+        (await dao.getBuildJobsForTeam(teamId: 'team-a')).map((job) => job.id),
+        ['unknown-ipa', 'no-ipa', 'ipa'],
+      );
+      expect(
+        (await dao.getBuildJobsForTeam(
+          teamId: 'team-a',
+          limit: 1,
+        )).map((job) => job.id),
+        ['unknown-ipa'],
+      );
+      expect(
+        (await dao.getBuildJobsForTeam(
+          teamId: 'team-a',
+          hasIpa: true,
+          limit: 1,
+        )).map((job) => job.id),
+        ['ipa'],
+      );
+      expect(
+        (await dao.getBuildJobsForTeam(
+          teamId: 'team-a',
+          hasIpa: false,
+        )).map((job) => job.id),
+        ['no-ipa'],
+      );
+      expect(await dao.getBuildJobsForTeam(teamId: 'missing'), isEmpty);
+    });
+
+    test('team watch updates the filtered and limited result', () async {
+      final old = _job('old').copyWith(hasIpa: const Value(true));
+      final newest = _job(
+        'newest',
+      ).copyWith(createdAt: DateTime.utc(2026, 9, 2));
+      await dao.insertBuildJob(old);
+      await dao.insertBuildJob(newest);
+      await dao.insertBuildJob(
+        _job('other-team').copyWith(
+          teamId: const Value('other-team'),
+          hasIpa: const Value(true),
+          createdAt: DateTime.utc(2026, 9, 3),
+        ),
+      );
+      final updates = StreamIterator(
+        dao.watchBuildJobsForTeam(teamId: 'team-a', hasIpa: true, limit: 1),
+      );
+      addTearDown(updates.cancel);
+
+      expect(await updates.moveNext(), isTrue);
+      expect(updates.current.map((job) => job.id), ['old']);
+      await dao.updateBuildJob(newest.copyWith(hasIpa: const Value(true)));
+      expect(await updates.moveNext(), isTrue);
+      expect(updates.current.map((job) => job.id), ['newest']);
+      await dao.updateBuildJob(newest.copyWith(hasIpa: const Value(false)));
+      expect(await updates.moveNext(), isTrue);
+      expect(updates.current.map((job) => job.id), ['old']);
+    });
+
+    test('queued queries remove jobs when their status changes', () async {
+      final queued = _job('queued');
+      await dao.insertBuildJob(queued);
+      await dao.insertBuildJob(
+        _job('running').copyWith(status: BuildJobStatus.IN_PROGRESS),
+      );
+      await dao.insertBuildJob(
+        _job('waiting').copyWith(status: BuildJobStatus.WAITING),
+      );
+      final updates = StreamIterator(dao.watchQueuedJobs());
+      addTearDown(updates.cancel);
+
+      expect((await dao.getQueuedJobs()).map((job) => job.id), ['queued']);
+      expect(await updates.moveNext(), isTrue);
+      expect(updates.current.map((job) => job.id), ['queued']);
+      await dao.updateBuildJob(
+        queued.copyWith(status: BuildJobStatus.IN_PROGRESS),
+      );
+      expect(await updates.moveNext(), isTrue);
+      expect(updates.current, isEmpty);
+      expect(await dao.getQueuedJobs(), isEmpty);
+    });
+
+    test('incrementRunCount starts a null count at one', () async {
+      await dao.insertBuildJob(_job('first-run'));
+      final updatedAt = DateTime.utc(2026, 9, 2);
+
+      await dao.incrementRunCount(
+        id: 'first-run',
+        latestRunId: 'run-1',
+        updatedAt: updatedAt,
+      );
+
+      final job = (await dao.getBuildJob('first-run'))!;
+      expect(job.runCount, 1);
+      expect(job.latestRunId, 'run-1');
+      expect(job.updatedAt.toUtc(), updatedAt);
+    });
+
+    test(
+      'steps are ordered within a run and upsert preserves a single row',
+      () async {
+        final first = DriftBuildStep(
+          id: 'first',
+          runId: 'run-a',
+          name: 'Checkout',
+          status: BuildJobStatus.IN_PROGRESS,
+          durationMs: 0,
+          stepOrder: 0,
+          createdAt: DateTime.utc(2026, 9, 1),
+          updatedAt: DateTime.utc(2026, 9, 1),
+        );
+        await dao.insertBuildStep(first.copyWith(id: 'second', stepOrder: 1));
+        await dao.insertBuildStep(
+          first.copyWith(id: 'other-run', runId: 'run-b'),
+        );
+        await dao.insertBuildStep(first);
+        await dao.insertBuildStep(
+          first.copyWith(status: BuildJobStatus.SUCCESS, durationMs: 10),
+        );
+
+        final steps = await dao.getBuildSteps('run-a');
+        expect(steps.map((step) => step.id), ['first', 'second']);
+        expect(steps.first.status, BuildJobStatus.SUCCESS);
+        expect(steps.first.durationMs, 10);
+        expect(await dao.getBuildSteps('missing'), isEmpty);
+      },
+    );
+
+    test(
+      'step logs preserve insertion order and stay within their step',
+      () async {
+        await dao.insertBuildStepLog('step-a', 'first');
+        await dao.insertBuildStepLog('step-b', 'unrelated');
+        await dao.insertBuildStepLog('step-a', 'second');
+
+        expect(
+          (await dao.getBuildStepLogs('step-a')).map((log) => log.logContent),
+          ['first', 'second'],
+        );
+        expect(await dao.getBuildStepLogs('missing'), isEmpty);
+      },
+    );
 
     test('Job CRUD Operations', () async {
       final now = DateTime.now().toUtc();
@@ -173,3 +395,15 @@ void main() {
     );
   });
 }
+
+DriftBuildJob _job(String id) => DriftBuildJob(
+  id: id,
+  teamId: 'team-a',
+  status: BuildJobStatus.QUEUED,
+  owner: 'openci-org',
+  repo: 'openci',
+  workflowName: 'CI',
+  workflowFileName: 'ci.dart',
+  createdAt: DateTime.utc(2026, 9, 1),
+  updatedAt: DateTime.utc(2026, 9, 1),
+);

--- a/apps/openci_server/test/db/seed_dao_test.dart
+++ b/apps/openci_server/test/db/seed_dao_test.dart
@@ -1,0 +1,148 @@
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  group('SeedDao.ensureTestTeam', () {
+    test('creates the default team without a member', () async {
+      await db.seedDao.ensureTestTeam();
+
+      final team = (await db.teamDao.getTeam('test-team'))!;
+      expect(team.name, 'Test Team');
+      expect(team.installationIds, [12345678]);
+      expect(team.aiEnabled, isTrue);
+      expect(team.runNumber, 1);
+      expect(team.createdAt, team.updatedAt);
+      expect(await db.teamDao.getTeamMembers(team.id), isEmpty);
+    });
+
+    test('repeated seeding preserves team settings and membership', () async {
+      await db.seedDao.ensureTestTeam(
+        teamId: 'team-a',
+        name: 'Custom team',
+        installationId: 42,
+        userId: 'user-a',
+      );
+      final original = (await db.teamDao.getTeam('team-a'))!.copyWith(
+        aiEnabled: false,
+        runNumber: 9,
+      );
+      await db.teamDao.updateTeam(original);
+
+      await db.seedDao.ensureTestTeam(
+        teamId: 'team-a',
+        name: 'Replacement name',
+        installationId: 42,
+        userId: 'user-a',
+      );
+
+      expect((await db.teamDao.getTeam('team-a'))!.toJson(), original.toJson());
+      final members = await db.teamDao.getTeamMembers('team-a');
+      expect(members.map((member) => member.userId), ['user-a']);
+    });
+
+    test('adds installations and members only to the requested team', () async {
+      await db.seedDao.ensureTestTeam(
+        teamId: 'team-a',
+        installationId: 1,
+        userId: 'user-a',
+      );
+      await db.seedDao.ensureTestTeam(
+        teamId: 'team-b',
+        installationId: 2,
+        userId: 'user-b',
+      );
+
+      await db.seedDao.ensureTestTeam(
+        teamId: 'team-a',
+        installationId: 3,
+        userId: 'user-b',
+      );
+      await db.seedDao.ensureTestTeam(teamId: 'team-a', installationId: 3);
+
+      expect((await db.teamDao.getTeam('team-a'))!.installationIds, [1, 3]);
+      expect((await db.teamDao.getTeam('team-b'))!.installationIds, [2]);
+      expect(
+        (await db.teamDao.getTeamMembers('team-a')).map((m) => m.userId),
+        unorderedEquals(['user-a', 'user-b']),
+      );
+      expect(
+        (await db.teamDao.getTeamMembers('team-b')).map((m) => m.userId),
+        ['user-b'],
+      );
+    });
+
+    test('does not create a member for an empty user ID', () async {
+      await db.seedDao.ensureTestTeam(userId: '');
+
+      expect(await db.teamDao.getTeam('test-team'), isNotNull);
+      expect(await db.teamDao.getTeamMembers('test-team'), isEmpty);
+    });
+  });
+
+  group('SeedDao.createTestBuildJob', () {
+    test('persists distinct queued jobs with the local defaults', () async {
+      final first = await db.seedDao.createTestBuildJob();
+      final second = await db.seedDao.createTestBuildJob();
+
+      expect(first.id, startsWith('test-job-'));
+      expect(second.id, isNot(first.id));
+      final jobs = await db.buildJobDao.getQueuedJobs();
+      expect(jobs.map((job) => job.id), unorderedEquals([first.id, second.id]));
+      for (final job in jobs) {
+        expect(job.status, BuildJobStatus.QUEUED);
+        expect(job.owner, 'openci-org');
+        expect(job.repo, 'openci');
+        expect(job.workflowName, 'Test Workflow');
+        expect(job.workflowFileName, 'ci.yml');
+        expect(job.teamId, 'test-team');
+        expect(job.installationId, '12345678');
+        expect(job.commitSha, 'main');
+        expect(job.commitMessage, 'feat: Test build job created by seed');
+        expect(job.branch, 'main');
+        expect(job.runsOn, 'macos-latest');
+        expect(job.createdAt, job.updatedAt);
+      }
+    });
+
+    test(
+      'persists explicitly supplied workflow and repository values',
+      () async {
+        final created = await db.seedDao.createTestBuildJob(
+          runsOn: 'ubuntu-latest',
+          owner: 'example',
+          repo: 'mobile',
+          workflowName: 'Release',
+          workflowFileName: 'release.dart',
+          teamId: 'team-custom',
+          installationId: '98765',
+          commitSha: 'abc123',
+          commitMessage: 'Release app',
+          branch: 'release/v2',
+        );
+
+        final job = (await db.buildJobDao.getBuildJob(created.id))!;
+        expect(job.status, BuildJobStatus.QUEUED);
+        expect(job.owner, 'example');
+        expect(job.repo, 'mobile');
+        expect(job.workflowName, 'Release');
+        expect(job.workflowFileName, 'release.dart');
+        expect(job.teamId, 'team-custom');
+        expect(job.installationId, '98765');
+        expect(job.commitSha, 'abc123');
+        expect(job.commitMessage, 'Release app');
+        expect(job.branch, 'release/v2');
+        expect(job.runsOn, 'ubuntu-latest');
+      },
+    );
+  });
+}

--- a/apps/openci_server/test/github/github_service_test.dart
+++ b/apps/openci_server/test/github/github_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:github/github.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:openci_server/github/github_service.dart';
@@ -48,6 +49,416 @@ void main() {
       if (tempDir.existsSync()) {
         tempDir.deleteSync(recursive: true);
       }
+    });
+
+    MockClient apiClient(http.Response Function(http.Request) handleRequest) {
+      final client = MockClient((request) async {
+        if (request.method == 'POST' &&
+            request.url.path.endsWith('/access_tokens')) {
+          return _jsonResponse({'token': 'ghs_test_token'});
+        }
+        return handleRequest(request);
+      });
+      addTearDown(client.close);
+      return client;
+    }
+
+    group('listRepositories', () {
+      test(
+        'maps repository fields and defaults using the configured API host',
+        () async {
+          testEnv['GITHUB_API_BASE_URL'] = 'https://github.example.test/api/v3';
+          final requests = <http.Request>[];
+          final client = apiClient((request) {
+            requests.add(request);
+            return _jsonResponse({
+              'repositories': [
+                {
+                  'full_name': 'org/mobile',
+                  'name': 'mobile',
+                  'owner': {'login': 'org'},
+                  'private': true,
+                  'default_branch': 'develop',
+                },
+                <String, Object?>{},
+              ],
+            });
+          });
+
+          final repositories = await GitHubService.listRepositories(
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          );
+
+          expect(repositories, [
+            {
+              'fullName': 'org/mobile',
+              'name': 'mobile',
+              'owner': 'org',
+              'private': true,
+              'defaultBranch': 'develop',
+            },
+            {
+              'fullName': '',
+              'name': '',
+              'owner': '',
+              'private': false,
+              'defaultBranch': 'main',
+            },
+          ]);
+          expect(requests.single.method, 'GET');
+          expect(
+            requests.single.url.toString(),
+            'https://github.example.test/api/v3/installation/repositories',
+          );
+          expect(
+            requests.single.headers['authorization'],
+            'Bearer ghs_test_token',
+          );
+        },
+      );
+
+      test('returns an empty list when repositories are absent', () async {
+        final client = apiClient((_) => _jsonResponse({}));
+
+        expect(
+          await GitHubService.listRepositories(
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('propagates a repository API failure', () async {
+        final client = apiClient((_) => http.Response('Forbidden', 403));
+
+        await expectLater(
+          GitHubService.listRepositories(
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          throwsA(
+            isA<HttpException>().having(
+              (e) => e.message,
+              'message',
+              contains('403 Forbidden'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('listBranches', () {
+      test(
+        'preserves branch names and removes entries without a name',
+        () async {
+          final requests = <http.Request>[];
+          final client = apiClient((request) {
+            requests.add(request);
+            return _jsonResponse([
+              {'name': 'main'},
+              {'name': 'feature/new-ci'},
+              {'name': ''},
+              {'name': null},
+              {},
+            ]);
+          });
+
+          final branches = await GitHubService.listBranches(
+            owner: 'org',
+            repo: 'mobile',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          );
+
+          expect(branches, ['main', 'feature/new-ci']);
+          expect(requests.single.url.path, '/repos/org/mobile/branches');
+          expect(
+            requests.single.headers['authorization'],
+            'Bearer ghs_test_token',
+          );
+        },
+      );
+
+      test('propagates a branch API failure', () async {
+        final client = apiClient((_) => http.Response('Not Found', 404));
+
+        await expectLater(
+          GitHubService.listBranches(
+            owner: 'org',
+            repo: 'mobile',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          throwsA(
+            isA<HttpException>().having(
+              (e) => e.message,
+              'message',
+              contains('404 Not Found'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('fetchWorkflowContent', () {
+      test(
+        'fetches Dart from genuine_ci at the commit using an existing token',
+        () async {
+          final requests = <http.Request>[];
+          const content = '// 日本語のワークフロー\nvoid main() {}\n';
+          final encoded = base64Encode(utf8.encode(content));
+          final client = MockClient((request) async {
+            requests.add(request);
+            return _jsonResponse({
+              'content':
+                  '${encoded.substring(0, 8)}\n ${encoded.substring(8)}\n',
+            });
+          });
+          addTearDown(client.close);
+
+          final result = await GitHubService.fetchWorkflowContent(
+            owner: 'org',
+            repo: 'mobile',
+            workflowFileName: 'ci.dart',
+            installationIdStr: '98765',
+            token: 'existing-token',
+            commitSha: 'abc123',
+            branch: 'develop',
+            environment: {},
+            client: client,
+          );
+
+          expect(result, content);
+          expect(requests.single.method, 'GET');
+          expect(
+            requests.single.url.toString(),
+            'https://api.github.com/repos/org/mobile/contents/genuine_ci/ci.dart?ref=abc123',
+          );
+          expect(
+            requests.single.headers['authorization'],
+            'Bearer existing-token',
+          );
+        },
+      );
+
+      test('fetches YAML from .openci and encodes the branch ref', () async {
+        final requests = <http.Request>[];
+        final client = apiClient((request) {
+          requests.add(request);
+          return _jsonResponse({'content': 'name: CI\n', 'encoding': 'utf-8'});
+        });
+
+        final result = await GitHubService.fetchWorkflowContent(
+          owner: 'org',
+          repo: 'mobile',
+          workflowFileName: 'ci.yml',
+          installationIdStr: '98765',
+          branch: 'feature/ci & tests',
+          environment: testEnv,
+          client: client,
+        );
+
+        expect(result, 'name: CI\n');
+        expect(
+          requests.single.url.path,
+          '/repos/org/mobile/contents/.openci/ci.yml',
+        );
+        expect(requests.single.url.queryParameters, {
+          'ref': 'feature/ci & tests',
+        });
+      });
+
+      test('omits the ref query when no revision is specified', () async {
+        final requests = <http.Request>[];
+        final client = apiClient((request) {
+          requests.add(request);
+          return _jsonResponse({'content': '', 'encoding': 'base64'});
+        });
+
+        expect(
+          await GitHubService.fetchWorkflowContent(
+            owner: 'org',
+            repo: 'mobile',
+            workflowFileName: 'ci.dart',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          '',
+        );
+        expect(requests.single.url.query, isEmpty);
+      });
+
+      test('reports a missing workflow', () async {
+        final client = apiClient((_) => http.Response('Not Found', 404));
+
+        await expectLater(
+          GitHubService.fetchWorkflowContent(
+            owner: 'org',
+            repo: 'mobile',
+            workflowFileName: 'ci.dart',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          throwsA(
+            isA<HttpException>().having(
+              (e) => e.message,
+              'message',
+              contains('404 Not Found'),
+            ),
+          ),
+        );
+      });
+
+      test('rejects a response without file content', () async {
+        final client = apiClient((_) => _jsonResponse({'encoding': 'base64'}));
+
+        await expectLater(
+          GitHubService.fetchWorkflowContent(
+            owner: 'org',
+            repo: 'mobile',
+            workflowFileName: 'ci.dart',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              'No content in GitHub response',
+            ),
+          ),
+        );
+      });
+
+      test(
+        'rejects invalid base64 rather than returning corrupted source',
+        () async {
+          final client = apiClient((_) => _jsonResponse({'content': '***'}));
+
+          await expectLater(
+            GitHubService.fetchWorkflowContent(
+              owner: 'org',
+              repo: 'mobile',
+              workflowFileName: 'ci.dart',
+              installationIdStr: '98765',
+              environment: testEnv,
+              client: client,
+            ),
+            throwsFormatException,
+          );
+        },
+      );
+    });
+
+    group('fetchGenuineCiFiles', () {
+      test(
+        'loads Dart files at the same commit and excludes other entries',
+        () async {
+          final requests = <http.Request>[];
+          const sources = {
+            'genuine_ci/ci.dart': '// ビルド\nvoid main() {}\n',
+            'genuine_ci/secrets.g.dart': 'const secretName = "API_TOKEN";\n',
+          };
+          final client = apiClient((request) {
+            requests.add(request);
+            if (request.url.path.endsWith('/contents/genuine_ci')) {
+              return _jsonResponse([
+                for (final path in sources.keys)
+                  {'type': 'file', 'name': path.split('/').last, 'path': path},
+                {
+                  'type': 'file',
+                  'name': 'README.md',
+                  'path': 'genuine_ci/README.md',
+                },
+                {
+                  'type': 'dir',
+                  'name': 'helpers',
+                  'path': 'genuine_ci/helpers',
+                },
+              ]);
+            }
+            final path = request.url.path.split('/contents/').last;
+            return _jsonResponse({
+              'type': 'file',
+              'content': base64Encode(utf8.encode(sources[path]!)),
+            });
+          });
+
+          final files = await GitHubService.fetchGenuineCiFiles(
+            owner: 'org',
+            repo: 'mobile',
+            commitSha: 'abc123',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          );
+
+          expect(files.map((file) => file.name), ['ci.dart', 'secrets.g.dart']);
+          expect({for (final file in files) file.path: file.content}, sources);
+          expect(requests.map((request) => request.url.path), [
+            '/repos/org/mobile/contents/genuine_ci',
+            '/repos/org/mobile/contents/genuine_ci/ci.dart',
+            '/repos/org/mobile/contents/genuine_ci/secrets.g.dart',
+          ]);
+          for (final request in requests) {
+            expect(request.method, 'GET');
+            expect(request.url.queryParameters, {'ref': 'abc123'});
+            expect(
+              request.headers['authorization'],
+              contains('ghs_test_token'),
+            );
+          }
+        },
+      );
+
+      test('returns no files if genuine_ci does not exist', () async {
+        final client = apiClient(
+          (_) => _jsonResponse({'message': 'Not Found'}, statusCode: 404),
+        );
+
+        expect(
+          await GitHubService.fetchGenuineCiFiles(
+            owner: 'org',
+            repo: 'mobile',
+            commitSha: 'abc123',
+            installationIdStr: '98765',
+            environment: testEnv,
+            client: client,
+          ),
+          isEmpty,
+        );
+      });
+
+      test(
+        'propagates access errors instead of treating the directory as empty',
+        () async {
+          final client = apiClient(
+            (_) => _jsonResponse({'message': 'Forbidden'}, statusCode: 403),
+          );
+
+          await expectLater(
+            GitHubService.fetchGenuineCiFiles(
+              owner: 'org',
+              repo: 'mobile',
+              commitSha: 'abc123',
+              installationIdStr: '98765',
+              environment: testEnv,
+              client: client,
+            ),
+            throwsA(isA<GitHubError>()),
+          );
+        },
+      );
     });
 
     group('generateJwt', () {
@@ -376,3 +787,10 @@ void main() {
     });
   });
 }
+
+http.Response _jsonResponse(Object body, {int statusCode = 200}) =>
+    http.Response(
+      jsonEncode(body),
+      statusCode,
+      headers: {'content-type': 'application/json; charset=utf-8'},
+    );

--- a/apps/openci_server/test/routes/builds/claim_test.dart
+++ b/apps/openci_server/test/routes/builds/claim_test.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_server/build_job/build_job_dao.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+import '../../../routes/builds/claim.dart' as route;
+
+class _MockDatabase extends Mock implements AppDatabase {}
+
+class _MockBuildJobDao extends Mock implements BuildJobDao {}
+
+void main() {
+  late AppDatabase db;
+  late BuildJobDao dao;
+
+  setUp(() {
+    db = _MockDatabase();
+    dao = _MockBuildJobDao();
+    when(() => db.buildJobDao).thenReturn(dao);
+  });
+
+  Future<Response> request({
+    HttpMethod method = HttpMethod.post,
+    String? uid = 'worker',
+    String body = '{}',
+  }) {
+    final context = TestRequestContext(
+      path: '/builds/claim',
+      method: method,
+      body: body,
+    );
+    context.provide<AppDatabase>(db);
+    context.provide<String?>(uid);
+    return Future.value(route.onRequest(context.context));
+  }
+
+  group('POST /builds/claim', () {
+    test('rejects other methods without claiming a job', () async {
+      expect(
+        (await request(method: HttpMethod.get)).statusCode,
+        HttpStatus.methodNotAllowed,
+      );
+      verifyZeroInteractions(dao);
+    });
+
+    test('requires authentication before claiming a job', () async {
+      final response = await request(uid: null);
+
+      expect(response.statusCode, HttpStatus.unauthorized);
+      expect(await response.json(), {
+        'success': false,
+        'error': 'Authentication required',
+      });
+      verifyZeroInteractions(dao);
+    });
+
+    for (final body in ['not-json', '[]']) {
+      test('rejects invalid request body: $body', () async {
+        final response = await request(body: body);
+
+        expect(response.statusCode, HttpStatus.badRequest);
+        verifyZeroInteractions(dao);
+      });
+    }
+
+    test('returns a null job when nothing can be claimed', () async {
+      when(() => dao.claimNextJob()).thenAnswer((_) async => null);
+
+      final response = await request();
+
+      expect(response.statusCode, HttpStatus.ok);
+      expect(await response.json(), {'job': null});
+      verify(() => dao.claimNextJob()).called(1);
+    });
+
+    test(
+      'passes worker settings to the DAO and returns the public job',
+      () async {
+        final job = DriftBuildJob(
+          id: 'job-1',
+          status: BuildJobStatus.IN_PROGRESS,
+          owner: 'org',
+          repo: 'repo',
+          workflowName: 'CI',
+          workflowFileName: 'ci.dart',
+          vmName: 'vm-a',
+          workerHost: 'host-a',
+          installationId: '98765',
+          checkRunId: '123',
+          createdAt: DateTime.utc(2026, 9, 1),
+          updatedAt: DateTime.utc(2026, 9, 1),
+        );
+        when(
+          () => dao.claimNextJob(
+            vmName: 'vm-a',
+            workerHost: 'host-a',
+            maxConcurrentJobs: 2,
+          ),
+        ).thenAnswer((_) async => job);
+
+        final response = await request(
+          body: jsonEncode({
+            'vmName': 'vm-a',
+            'workerHost': 'host-a',
+            'maxConcurrentJobs': 2,
+          }),
+        );
+
+        expect(response.statusCode, HttpStatus.ok);
+        final body = await response.json() as Map<String, dynamic>;
+        final returned = body['job'] as Map<String, dynamic>;
+        expect(BuildJob.fromJson(returned).id, 'job-1');
+        expect(returned['status'], 'IN_PROGRESS');
+        expect(returned['vmName'], 'vm-a');
+        expect(returned['workerHost'], 'host-a');
+        expect(returned, isNot(contains('installationId')));
+        expect(returned, isNot(contains('checkRunId')));
+        verify(
+          () => dao.claimNextJob(
+            vmName: 'vm-a',
+            workerHost: 'host-a',
+            maxConcurrentJobs: 2,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
- Introduced integration tests for PostgreSQL, including setup and teardown instructions in README.md.
- Created build_job_claim_test.dart to test job claiming functionality in the database.
- Added seed_dao_test.dart to validate team and job seeding logic.
- Implemented build_job_mapper_test.dart to ensure correct grouping and partitioning of build jobs.
- Enhanced GitHub service tests in github_service_test.dart to cover repository and branch listing, workflow content fetching, and error handling.
- Added mock database and job DAO for testing routes in claim_test.dart.