### PR TITLE
Add comprehensive tests for team members, secrets, workflows, and web…

### DIFF
--- a/apps/build_job_worker/test/src/orchard/exec_command_web_socket_test.dart
+++ b/apps/build_job_worker/test/src/orchard/exec_command_web_socket_test.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:build_job_worker/build_job_worker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late HttpServer server;
+  late OrchardApiClient api;
+  late List<Object> frames;
+  late List<WebSocket> sockets;
+  late List<(String, String)> logs;
+  late Completer<void> peerClosed;
+  late bool closeBeforeExit;
+  late bool rejectUpgrade;
+
+  setUp(() async {
+    frames = [];
+    sockets = [];
+    logs = [];
+    peerClosed = Completer<void>();
+    closeBeforeExit = false;
+    rejectUpgrade = false;
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    api = OrchardApiClient(
+      config: Config(
+        serverUrl: 'http://localhost:8080',
+        internalApiKey: 'test-api-key',
+        orchardApiUrl: 'http://127.0.0.1:${server.port}/orchard/',
+        orchardServiceAccountName: 'worker',
+        orchardServiceAccountToken: 'test-token',
+      ),
+    );
+    server.listen((request) async {
+      expect(request.uri.pathSegments, [
+        'orchard',
+        'v1',
+        'vms',
+        'vm /?#1',
+        'exec',
+      ]);
+      expect(request.uri.queryParameters, {
+        'command': 'echo "hello & world"',
+        'wait': '120',
+      });
+      expect(
+        request.headers.value(HttpHeaders.authorizationHeader),
+        'Basic ${base64Encode(utf8.encode('worker:test-token'))}',
+      );
+      if (rejectUpgrade) {
+        request.response.statusCode = HttpStatus.unauthorized;
+        await request.response.close();
+        return;
+      }
+      final socket = await WebSocketTransformer.upgrade(request);
+      sockets.add(socket);
+      socket.listen(
+        (_) {},
+        onDone: () {
+          if (!peerClosed.isCompleted) peerClosed.complete();
+        },
+      );
+      for (final frame in frames) {
+        socket.add(frame);
+      }
+      if (closeBeforeExit) await socket.close();
+    });
+  });
+
+  tearDown(() async {
+    api.close();
+    for (final socket in sockets) {
+      await socket.close();
+    }
+    await server.close(force: true);
+  });
+
+  Future<int> execute({void Function(String, String)? onLog}) =>
+      api.execCommandWebSocket(
+        vmName: 'vm /?#1',
+        command: 'echo "hello & world"',
+        waitSeconds: 120,
+        onLog: onLog ?? (line, stream) => logs.add((line, stream)),
+      );
+
+  Future<void> expectClosed() =>
+      peerClosed.future.timeout(const Duration(seconds: 5));
+
+  group('execCommandWebSocket', () {
+    test(
+      'decodes split UTF-8, separates streams, and flushes final lines',
+      () async {
+        final japanese = utf8.encode('日本語');
+        frames = [
+          _output('stdout', [...utf8.encode('hello\n\n'), ...japanese.take(2)]),
+          utf8.encode(_output('stderr', utf8.encode('warning\r\n'))),
+          _output('stdout', [
+            ...japanese.skip(2),
+            ...utf8.encode('\r\nfinal-out'),
+          ]),
+          _output('stderr', utf8.encode('final-err')),
+          jsonEncode({'type': 'heartbeat'}),
+          jsonEncode({
+            'type': 'exit',
+            'exit': {'code': 23},
+          }),
+        ];
+
+        expect(await execute(), 23);
+        expect(logs, [
+          ('hello', 'stdout'),
+          ('warning', 'stderr'),
+          ('日本語', 'stdout'),
+          ('final-out', 'stdout'),
+          ('final-err', 'stderr'),
+        ]);
+        await expectClosed();
+      },
+    );
+
+    test(
+      'returns zero for a silent command and closes the connection',
+      () async {
+        frames = [
+          jsonEncode({
+            'type': 'exit',
+            'exit': {'code': 0},
+          }),
+        ];
+        expect(await execute(), 0);
+        expect(logs, isEmpty);
+        await expectClosed();
+      },
+    );
+
+    for (final frame in [
+      'not json',
+      '[]',
+      jsonEncode({'type': 'stdout', 'data': 42}),
+      jsonEncode({'type': 'stderr', 'data': '%%%'}),
+      jsonEncode({'type': 'exit', 'exit': null}),
+      jsonEncode({
+        'type': 'exit',
+        'exit': {'code': '0'},
+      }),
+    ]) {
+      test(
+        'rejects malformed message $frame and closes the connection',
+        () async {
+          frames = [frame];
+          await expectLater(execute(), throwsFormatException);
+          expect(logs, isEmpty);
+          await expectClosed();
+        },
+      );
+    }
+
+    test('reports an Orchard error and flushes buffered output', () async {
+      frames = [
+        _output('stderr', utf8.encode('last diagnostic')),
+        jsonEncode({'type': 'error', 'error': 'execution denied'}),
+      ];
+      await expectLater(
+        execute(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('execution denied'),
+          ),
+        ),
+      );
+      expect(logs, [('last diagnostic', 'stderr')]);
+      await expectClosed();
+    });
+
+    test(
+      'rejects a connection closed before exit and retains final output',
+      () async {
+        frames = [_output('stdout', utf8.encode('partial output'))];
+        closeBeforeExit = true;
+        await expectLater(
+          execute(),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('closed before exit'),
+            ),
+          ),
+        );
+        expect(logs, [('partial output', 'stdout')]);
+        await expectClosed();
+      },
+    );
+
+    test('closes the socket when the log callback throws', () async {
+      frames = [_output('stdout', utf8.encode('line\n'))];
+      final error = StateError('log consumer failed');
+      await expectLater(
+        execute(onLog: (_, _) => throw error),
+        throwsA(same(error)),
+      );
+      await expectClosed();
+    });
+
+    test('propagates a rejected WebSocket handshake without logging', () async {
+      rejectUpgrade = true;
+      await expectLater(execute(), throwsA(isA<WebSocketException>()));
+      expect(logs, isEmpty);
+      expect(sockets, isEmpty);
+    });
+  });
+}
+
+String _output(String stream, List<int> bytes) =>
+    jsonEncode({'type': stream, 'data': base64Encode(bytes)});

--- a/apps/genuineci_cli/test/src/commands/use_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/use_command_test.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:genuineci_cli/genuineci_cli.dart';
+import 'package:test/test.dart';
+
+class _RecordingLogger implements Logger {
+  final output = <String>[];
+  final errors = <String>[];
+
+  @override
+  void stdout(String message) => output.add(message);
+
+  @override
+  void stderr(String message) => errors.add(message);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late Directory directory;
+  late CliConfig config;
+  late EditLanguageConfig language;
+  late _RecordingLogger logger;
+  late CommandRunner<int> runner;
+  late AppLocale originalLocale;
+
+  setUp(() async {
+    originalLocale = LocaleSettings.currentLocale;
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    directory = await Directory.systemTemp.createTemp(
+      'genuineci-language-test-',
+    );
+    config = CliConfig(customFilePath: '${directory.path}/config.json');
+    language = EditLanguageConfig(config: config);
+    logger = _RecordingLogger();
+    runner = CommandRunner<int>('genuineci', 'test')
+      ..addCommand(UseCommand(languageConfig: language, logger: logger));
+  });
+
+  tearDown(() async {
+    LocaleSettings.setLocaleSync(originalLocale);
+    await directory.delete(recursive: true);
+  });
+
+  for (final (input, code, locale, label) in [
+    ('japanese', 'ja', AppLocale.ja, 'Japanese'),
+    ('english', 'en', AppLocale.en, 'English'),
+    ('  JAPANESE  ', 'ja', AppLocale.ja, 'Japanese'),
+    ('  English  ', 'en', AppLocale.en, 'English'),
+  ]) {
+    test('use $input persists and restores the selected language', () async {
+      expect(await runner.run(['use', input]), 0);
+      expect(await language.getLanguage(), code);
+      expect(LocaleSettings.currentLocale, locale);
+      expect(logger.output, [t.use.success(language: label)]);
+      expect(logger.errors, isEmpty);
+
+      LocaleSettings.setLocaleSync(
+        locale == AppLocale.en ? AppLocale.ja : AppLocale.en,
+      );
+      await initI18n(
+        languageConfig: EditLanguageConfig(
+          config: CliConfig(customFilePath: config.filePath),
+        ),
+      );
+      expect(LocaleSettings.currentLocale, locale);
+    });
+  }
+
+  test(
+    'missing arguments preserve the saved language and report usage',
+    () async {
+      await language.setLanguage('ja');
+      final before = await File(config.filePath).readAsString();
+      expect(await runner.run(['use']), 64);
+      expect(await File(config.filePath).readAsString(), before);
+      expect(LocaleSettings.currentLocale, AppLocale.ja);
+      expect(logger.output, isEmpty);
+      expect(logger.errors, ['Usage: genuineci use <japanese|english>']);
+    },
+  );
+
+  test('unknown language does not change the file or active locale', () async {
+    await language.setLanguage('ja');
+    final before = await File(config.filePath).readAsString();
+    expect(await runner.run(['use', 'klingon']), 1);
+    expect(await File(config.filePath).readAsString(), before);
+    expect(LocaleSettings.currentLocale, AppLocale.ja);
+    expect(logger.output, isEmpty);
+    expect(logger.errors, [t.use.invalidLanguage(input: 'klingon')]);
+  });
+
+  test(
+    'failed persistence does not report success or change the locale',
+    () async {
+      await Directory(config.filePath).create();
+      await expectLater(
+        runner.run(['use', 'japanese']),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(LocaleSettings.currentLocale, AppLocale.en);
+      expect(logger.output, isEmpty);
+      expect(await Directory(config.filePath).exists(), isTrue);
+      expect(await directory.list().map((entry) => entry.path).toList(), [
+        config.filePath,
+      ]);
+    },
+  );
+
+  test(
+    'startup defaults to English without creating a configuration file',
+    () async {
+      LocaleSettings.setLocaleSync(AppLocale.ja);
+      await initI18n(languageConfig: language);
+      expect(LocaleSettings.currentLocale, AppLocale.en);
+      expect(await File(config.filePath).exists(), isFalse);
+    },
+  );
+
+  test('startup uses English for an unsupported stored locale', () async {
+    await config.set(const CliConfigData(language: 'unsupported'));
+    LocaleSettings.setLocaleSync(AppLocale.ja);
+    await initI18n(languageConfig: language);
+    expect(LocaleSettings.currentLocale, AppLocale.en);
+    expect((await config.get()).language, 'unsupported');
+  });
+
+  test(
+    'startup preserves malformed configuration and reports the error',
+    () async {
+      await File(config.filePath).writeAsString('{');
+      await expectLater(
+        initI18n(languageConfig: language),
+        throwsFormatException,
+      );
+      expect(LocaleSettings.currentLocale, AppLocale.en);
+      expect(await File(config.filePath).readAsString(), '{');
+    },
+  );
+}

--- a/apps/openci_server/routes/_middleware.dart
+++ b/apps/openci_server/routes/_middleware.dart
@@ -114,16 +114,18 @@ Middleware authProvider(FirebaseApp? firebaseApp, {bool allowTestUid = false}) {
       if (token == null || token.isEmpty) {
         return handler(context.provide<String?>(() => null));
       }
+      final String uid;
       try {
         final decodedToken = await firebaseApp.auth().verifyIdToken(
           token,
           checkRevoked: false,
         );
-        return await handler(context.provide<String?>(() => decodedToken.uid));
+        uid = decodedToken.uid;
       } catch (e) {
         stderr.writeln('Token verification failed: $e');
         return handler(context.provide<String?>(() => null));
       }
+      return handler(context.provide<String?>(() => uid));
     };
   };
 }

--- a/apps/openci_server/test/routes/_middleware_test.dart
+++ b/apps/openci_server/test/routes/_middleware_test.dart
@@ -1,9 +1,12 @@
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/native.dart';
 import 'package:firebase_admin_sdk/auth.dart';
 import 'package:firebase_admin_sdk/firebase_admin_sdk.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openci_server/database.dart';
 import 'package:test/test.dart';
 
 import '../../routes/_middleware.dart';
@@ -21,6 +24,60 @@ class MockRequest extends Mock implements Request {}
 void main() {
   setUpAll(() {
     registerFallbackValue(() => 'dummy');
+  });
+
+  test(
+    'databaseProvider makes the same database available downstream',
+    () async {
+      final db = AppDatabase(NativeDatabase.memory());
+      addTearDown(db.close);
+      final context = MockRequestContext();
+      registerFallbackValue(() => db);
+      when(() => context.provide<AppDatabase>(any())).thenAnswer((invocation) {
+        final create =
+            invocation.positionalArguments.single as AppDatabase Function();
+        expect(create(), same(db));
+        return context;
+      });
+      final handler = databaseProvider(db)(
+        (_) => Response(statusCode: 201, body: 'created'),
+      );
+      final response = await handler(context);
+      expect(response.statusCode, 201);
+      expect(await response.body(), 'created');
+    },
+  );
+
+  group('sentryMiddleware', () {
+    test('preserves a successful downstream response', () async {
+      final context = TestRequestContext(path: '/');
+      final expected = Response(statusCode: 202, body: 'accepted');
+      final handler = sentryMiddleware()((_) => expected);
+      expect(await handler(context.context), same(expected));
+    });
+
+    test(
+      'returns a generic error without exposing exception details',
+      () async {
+        final context = TestRequestContext(path: '/');
+        final handler = sentryMiddleware()((_) async {
+          throw StateError('private exception detail');
+        });
+        final response = await handler(context.context);
+        expect(response.statusCode, HttpStatus.internalServerError);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Internal server error',
+        });
+      },
+    );
+
+    test('propagates hijack exceptions for streaming responses', () async {
+      final context = TestRequestContext(path: '/');
+      final error = StateError('request hijack');
+      final handler = sentryMiddleware()((_) async => throw error);
+      await expectLater(handler(context.context), throwsA(same(error)));
+    });
   });
 
   group('corsMiddleware', () {
@@ -227,6 +284,35 @@ void main() {
               ).captured.single
               as String? Function();
       expect(captured(), equals('user-firebase-123'));
+    });
+
+    test('does not retry an authenticated handler when it throws', () async {
+      when(() => mockFirebaseApp.auth()).thenReturn(mockAuth);
+      when(
+        () => mockAuth.verifyIdToken('valid-token', checkRevoked: false),
+      ).thenAnswer((_) async => mockToken);
+      when(() => mockToken.uid).thenReturn('user-1');
+      when(
+        () => mockRequest.uri,
+      ).thenReturn(Uri.parse('http://localhost/teams'));
+      when(() => mockRequest.headers).thenReturn({
+        'authorization': 'Bearer valid-token',
+      });
+      final error = StateError('downstream request failed');
+      var handlerCalls = 0;
+      final handler = authProvider(mockFirebaseApp)((_) async {
+        handlerCalls++;
+        throw error;
+      });
+
+      await expectLater(handler(mockContext), throwsA(same(error)));
+      expect(handlerCalls, 1);
+      final captured =
+          verify(
+                () => mockContext.provide<String?>(captureAny()),
+              ).captured.single
+              as String? Function();
+      expect(captured(), 'user-1');
     });
 
     test(

--- a/apps/openci_server/test/routes/builds/[id]/runs/[runId]_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs/[runId]_test.dart
@@ -164,6 +164,28 @@ void main() {
   });
 
   group('PATCH /builds/<id>/runs/<runId>', () {
+    test('rejects an empty status without writing a build run', () async {
+      final context = TestRequestContext(
+        path: '/builds/job-xyz/runs/run-456',
+        method: HttpMethod.patch,
+        body: '{"status": ""}',
+      );
+      context.provide<AppDatabase>(db);
+
+      final response = await route.onRequest(
+        context.context,
+        'job-xyz',
+        'run-456',
+      );
+
+      expect(response.statusCode, HttpStatus.badRequest);
+      expect(await response.json(), {
+        'success': false,
+        'error': 'status is required',
+      });
+      expect(await db.select(db.buildRuns).get(), isEmpty);
+    });
+
     test(
       'responds with 400 Bad Request when body is invalid JSON',
       () async {

--- a/apps/openci_server/test/routes/builds/[id]/secrets_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/secrets_test.dart
@@ -32,6 +32,7 @@ void main() {
     }
   ''';
   late AppDatabase db;
+  late SecretDao dao;
   late Directory tempDir;
   late Map<String, String> environment;
   late List<String> requestedFiles;
@@ -65,7 +66,7 @@ void main() {
           updatedAt: now,
         ),
     ];
-    final dao = _MockSecretDao();
+    dao = _MockSecretDao();
     db = _MockAppDatabase();
     when(() => db.secretDao).thenReturn(dao);
     when(
@@ -80,8 +81,10 @@ void main() {
   Future<Response> requestSecrets({
     required String workflow,
     String fileName = 'ci.dart',
+    String? installationId = '98765',
     String? commitSha = 'job-commit',
     int definitionsStatus = 200,
+    HttpMethod method = HttpMethod.get,
   }) async {
     final directory = fileName.endsWith('.dart') ? 'genuine_ci' : '.openci';
     final client = MockClient((request) async {
@@ -119,7 +122,7 @@ void main() {
 
     final context = TestRequestContext(
       path: '/builds/job-1/secrets',
-      method: HttpMethod.get,
+      method: method,
     );
     final now = DateTime.utc(2026, 9, 7);
     context.provide<DriftBuildJob>(
@@ -128,7 +131,7 @@ void main() {
         owner: 'owner',
         repo: 'repo',
         teamId: 'team-1',
-        installationId: '98765',
+        installationId: installationId,
         commitSha: commitSha,
         branch: 'feature/ci',
         status: BuildJobStatus.IN_PROGRESS,
@@ -145,6 +148,49 @@ void main() {
   }
 
   group('GET /builds/[id]/secrets', () {
+    test('rejects unsupported methods without fetching secrets', () async {
+      final response = await requestSecrets(
+        workflow: 'Secrets.ascKey;',
+        method: HttpMethod.post,
+      );
+
+      expect(response.statusCode, 405);
+      expect(requestedFiles, isEmpty);
+      verifyNever(() => dao.getSecretsForTeam('team-1'));
+    });
+
+    for (final installationId in [null, '']) {
+      test('rejects a missing installation ID: $installationId', () async {
+        final response = await requestSecrets(
+          workflow: 'Secrets.ascKey;',
+          installationId: installationId,
+        );
+
+        expect(response.statusCode, 400);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'No installationId found for job',
+        });
+        expect(requestedFiles, isEmpty);
+        verifyNever(() => dao.getSecretsForTeam('team-1'));
+      });
+    }
+
+    test('rejects a missing workflow filename', () async {
+      final response = await requestSecrets(
+        workflow: 'Secrets.ascKey;',
+        fileName: '',
+      );
+
+      expect(response.statusCode, 400);
+      expect(await response.json(), {
+        'success': false,
+        'error': 'No workflowFileName found for job',
+      });
+      expect(requestedFiles, isEmpty);
+      verifyNever(() => dao.getSecretsForTeam('team-1'));
+    });
+
     for (final commitSha in ['job-commit', null]) {
       test('resolves the getter using the same job ref: $commitSha', () async {
         final response = await requestSecrets(
@@ -219,6 +265,58 @@ void main() {
         'genuine_ci/ci.dart',
         'genuine_ci/secrets.g.dart',
       ]);
+    });
+
+    test('does not return partial credentials when decryption fails', () async {
+      final now = DateTime.utc(2026, 9, 7);
+      when(() => dao.getSecretsForTeam('team-1')).thenAnswer(
+        (_) async => [
+          DriftSecret(
+            name: 'ASC_KEY',
+            teamId: 'team-1',
+            encryptedValue: 'invalid-ciphertext',
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ],
+      );
+
+      final response = await requestSecrets(workflow: 'Secrets.ascKey;');
+
+      verify(() => dao.getSecretsForTeam('team-1')).called(1);
+      expect(response.statusCode, 500);
+      expect(await response.json(), {
+        'success': false,
+        'error': 'Internal server error',
+      });
+    });
+
+    test('escapes multiline secret values in the environment file', () async {
+      final now = DateTime.utc(2026, 9, 7);
+      final encrypted = await SecretCrypter(encryptionKey).encrypt(
+        '-----BEGIN KEY-----\nsecret value\n-----END KEY-----\n',
+      );
+      when(() => dao.getSecretsForTeam('team-1')).thenAnswer(
+        (_) async => [
+          DriftSecret(
+            name: 'ASC_KEY',
+            teamId: 'team-1',
+            encryptedValue: encrypted,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ],
+      );
+
+      final response = await requestSecrets(workflow: 'Secrets.ascKey;');
+
+      expect(response.statusCode, 200);
+      final body = await response.json() as Map<String, dynamic>;
+      expect(
+        body['secretsContent'],
+        'GITHUB_TOKEN=$token\n'
+        r'ASC_KEY=-----BEGIN KEY-----\nsecret value\n-----END KEY-----\n',
+      );
     });
   });
 }

--- a/apps/openci_server/test/routes/builds/[id]_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]_test.dart
@@ -164,6 +164,7 @@ void main() {
           'failureSummaryDurationMs': 1200,
           'ipaUrl': 'https://s3.example.com/build.ipa',
           'hasIpa': true,
+          'provisionedUdids': ['udid-1', 'udid-2'],
           'bundleId': 'com.example.app',
           'ipaVersion': '1.0.0',
           'appName': 'Test App',
@@ -201,6 +202,7 @@ void main() {
         expect(updatedDrift.failureSummaryDurationMs, equals(1200));
         expect(updatedDrift.ipaUrl, equals('https://s3.example.com/build.ipa'));
         expect(updatedDrift.hasIpa, isTrue);
+        expect(updatedDrift.provisionedUdids, ['udid-1', 'udid-2']);
         expect(updatedDrift.bundleId, equals('com.example.app'));
         expect(updatedDrift.ipaVersion, equals('1.0.0'));
         expect(updatedDrift.appName, equals('Test App'));

--- a/apps/openci_server/test/routes/database_failure_test.dart
+++ b/apps/openci_server/test/routes/database_failure_test.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:openci_server/build_job/build_job_mapper.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+import '../../routes/builds/[id]/index.dart' as build;
+import '../../routes/builds/[id]/runs/[runId]/index.dart' as run;
+import '../../routes/builds/[id]/runs/index.dart' as runs;
+import '../../routes/builds/index.dart' as builds;
+import '../../routes/devices/[id].dart' as device;
+import '../../routes/devices/index.dart' as devices;
+import '../../routes/teams/[id].dart' as team;
+import '../../routes/teams/[id]/github/repositories.dart' as repositories;
+import '../../routes/teams/[id]/github/repositories/[owner]/[repo]/branches.dart'
+    as branches;
+import '../../routes/teams/[id]/repositories/[repo]/genuine-ci-files.dart'
+    as workflow_files;
+import '../../routes/teams/[id]/udid-requests.dart' as udid_requests;
+import '../../routes/teams/index.dart' as teams;
+import '../../routes/workers/heartbeat.dart' as heartbeat;
+import '../../routes/workers/index.dart' as workers;
+
+class _UnavailableDatabase implements AppDatabase {
+  var accesses = 0;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    accesses++;
+    throw StateError('private database connection detail');
+  }
+}
+
+class _Endpoint {
+  const _Endpoint(
+    this.path,
+    this.method,
+    this.handle, {
+    this.body = '{}',
+    this.uid = 'user-1',
+  });
+
+  final String path;
+  final HttpMethod method;
+  final FutureOr<Response> Function(RequestContext) handle;
+  final String body;
+  final String uid;
+}
+
+void main() {
+  final job = DriftBuildJob(
+    id: 'job-1',
+    status: BuildJobStatus.QUEUED,
+    owner: 'owner',
+    repo: 'repo',
+    workflowName: 'build',
+    workflowFileName: 'build.dart',
+    teamId: 'team-1',
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+  final endpoints = [
+    _Endpoint('/teams', HttpMethod.get, teams.onRequest),
+    _Endpoint(
+      '/teams',
+      HttpMethod.post,
+      teams.onRequest,
+      body: '{"name":"New team"}',
+    ),
+    _Endpoint(
+      '/teams/team-1',
+      HttpMethod.patch,
+      (c) => team.onRequest(c, 'team-1'),
+    ),
+    _Endpoint(
+      '/teams/team-1',
+      HttpMethod.delete,
+      (c) => team.onRequest(c, 'team-1'),
+    ),
+    _Endpoint('/builds?teamId=team-1', HttpMethod.get, builds.onRequest),
+    _Endpoint(
+      '/builds',
+      HttpMethod.post,
+      builds.onRequest,
+      body: jsonEncode(job.toShared().toJson()),
+      uid: 'system-job-processor',
+    ),
+    _Endpoint(
+      '/builds/job-1',
+      HttpMethod.patch,
+      (c) => build.onRequest(c, 'job-1'),
+    ),
+    _Endpoint(
+      '/builds/job-1/runs',
+      HttpMethod.get,
+      (c) => runs.onRequest(c, 'job-1'),
+    ),
+    _Endpoint(
+      '/builds/job-1/runs',
+      HttpMethod.post,
+      (c) => runs.onRequest(c, 'job-1'),
+      body: '{"id":"run-1"}',
+    ),
+    _Endpoint(
+      '/builds/job-1/runs/run-1',
+      HttpMethod.get,
+      (c) => run.onRequest(c, 'job-1', 'run-1'),
+    ),
+    _Endpoint(
+      '/builds/job-1/runs/run-1',
+      HttpMethod.patch,
+      (c) => run.onRequest(c, 'job-1', 'run-1'),
+      body: '{"status":"completed"}',
+    ),
+    _Endpoint('/workers', HttpMethod.get, workers.onRequest),
+    _Endpoint(
+      '/workers/heartbeat',
+      HttpMethod.post,
+      heartbeat.onRequest,
+      body: '{"workerId":"worker-1"}',
+    ),
+    _Endpoint('/devices', HttpMethod.get, devices.onRequest),
+    _Endpoint(
+      '/devices/device-1',
+      HttpMethod.delete,
+      (c) => device.onRequest(c, 'device-1'),
+    ),
+    _Endpoint(
+      '/teams/team-1/github/repositories',
+      HttpMethod.get,
+      (c) => repositories.onRequest(c, 'team-1'),
+    ),
+    _Endpoint(
+      '/teams/team-1/github/repositories/owner/repo/branches',
+      HttpMethod.get,
+      (c) => branches.onRequest(c, 'team-1', 'owner', 'repo'),
+    ),
+    _Endpoint(
+      '/teams/team-1/repositories/repo/genuine-ci-files',
+      HttpMethod.get,
+      (c) => workflow_files.onRequest(c, 'team-1', 'repo'),
+    ),
+    _Endpoint(
+      '/teams/team-1/udid-requests',
+      HttpMethod.get,
+      (c) => udid_requests.onRequest(c, 'team-1'),
+    ),
+    _Endpoint(
+      '/teams/team-1/udid-requests',
+      HttpMethod.post,
+      (c) => udid_requests.onRequest(c, 'team-1'),
+      body: '{"udid":"device-1"}',
+    ),
+  ];
+
+  final checkedPaths = <String>{};
+  for (final endpoint in endpoints) {
+    test(
+      '${endpoint.method} ${endpoint.path} hides database failures',
+      () async {
+        final database = _UnavailableDatabase();
+        final context = TestRequestContext(
+          path: endpoint.path,
+          method: endpoint.method,
+          body: endpoint.body,
+        );
+        context.provide<AppDatabase>(database);
+        context.provide<String?>(endpoint.uid);
+        context.provide<DriftBuildJob>(job);
+
+        final response = await endpoint.handle(context.context);
+
+        expect(database.accesses, greaterThan(0));
+        expect(response.statusCode, HttpStatus.internalServerError);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Internal server error',
+        });
+      },
+    );
+
+    if (checkedPaths.add(Uri.parse(endpoint.path).path)) {
+      test(
+        'PUT ${endpoint.path} is rejected before accessing the database',
+        () async {
+          final database = _UnavailableDatabase();
+          final context = TestRequestContext(
+            path: endpoint.path,
+            method: HttpMethod.put,
+          );
+          context.provide<AppDatabase>(database);
+
+          final response = await endpoint.handle(context.context);
+
+          expect(response.statusCode, HttpStatus.methodNotAllowed);
+          expect(database.accesses, 0);
+        },
+      );
+    }
+  }
+}

--- a/apps/openci_server/test/routes/teams/branches_test.dart
+++ b/apps/openci_server/test/routes/teams/branches_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -73,6 +74,47 @@ void main() {
   });
 
   group('Branches Endpoint', () {
+    test(
+      'rejects a team without a GitHub installation before any request',
+      () async {
+        await db
+            .into(db.teamMembers)
+            .insert(
+              TeamMembersCompanion.insert(teamId: 'team-123', userId: 'user-1'),
+            );
+        await db
+            .update(db.teams)
+            .write(
+              const TeamsCompanion(installationIds: Value([])),
+            );
+        final client = MockClient((_) async {
+          fail('GitHub should not be called without an installation');
+        });
+        addTearDown(client.close);
+        final context = TestRequestContext(
+          path: '/teams/team-123/github/repositories/owner/repo/branches',
+          method: HttpMethod.get,
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+        context.provide<Map<String, String>>(testEnv);
+        context.provide<http.Client>(client);
+
+        final response = await branches_route.onRequest(
+          context.context,
+          'team-123',
+          'owner',
+          'repo',
+        );
+
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'GitHub App is not installed for this team',
+        });
+      },
+    );
+
     test('responds with 401 Unauthorized when uid is null', () async {
       final context = TestRequestContext(
         path: '/teams/team-123/github/repositories/owner/repo/branches',

--- a/apps/openci_server/test/routes/teams/genuine_ci_files_test.dart
+++ b/apps/openci_server/test/routes/teams/genuine_ci_files_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -147,6 +148,44 @@ void main() {
       expect(response.statusCode, HttpStatus.ok);
       expect(await response.json(), isEmpty);
     });
+
+    for (final (scenario, status, message) in [
+      ('missing team', HttpStatus.notFound, 'Team not found'),
+      (
+        'no installation',
+        HttpStatus.badRequest,
+        'GitHub App is not installed for this team',
+      ),
+      ('invalid installation', HttpStatus.badRequest, 'Invalid installationId'),
+    ]) {
+      test('rejects $scenario before contacting GitHub', () async {
+        if (scenario == 'missing team') {
+          await db.delete(db.teams).go();
+        } else if (scenario == 'no installation') {
+          await db
+              .update(db.teams)
+              .write(const TeamsCompanion(installationIds: Value([])));
+        }
+        final client = MockClient(
+          (_) async => fail('GitHub must not be contacted'),
+        );
+        addTearDown(client.close);
+        final context = _requestContext(
+          db: db,
+          path:
+              '/teams/team-123/repositories/openci/genuine-ci-files?owner=openci-org&installationId=not-a-number',
+          environment: environment,
+          client: client,
+        );
+        final response = await route.onRequest(
+          context.context,
+          'team-123',
+          'openci',
+        );
+        expect(response.statusCode, status);
+        expect(await response.json(), {'success': false, 'error': message});
+      });
+    }
 
     test('requires owner', () async {
       final context = _requestContext(

--- a/apps/openci_server/test/routes/teams/index_test.dart
+++ b/apps/openci_server/test/routes/teams/index_test.dart
@@ -162,6 +162,26 @@ void main() {
   });
 
   group('POST /teams', () {
+    for (final id in [42, '   ']) {
+      test('rejects invalid team ID $id without creating a team', () async {
+        final before = await db.select(db.teams).get();
+        final context = TestRequestContext(
+          path: '/teams',
+          method: HttpMethod.post,
+          body: jsonEncode({'name': 'New team', 'id': id}),
+        );
+        context.provide<AppDatabase>(db);
+        context.provide<String?>('user-1');
+        final response = await route.onRequest(context.context);
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': id is String ? 'id cannot be empty' : 'id must be a string',
+        });
+        expect(await db.select(db.teams).get(), before);
+      });
+    }
+
     test(
       'responds with 401 Unauthorized when unauthorized (uid is null)',
       () async {

--- a/apps/openci_server/test/routes/teams/ios_signing_generate_key_test.dart
+++ b/apps/openci_server/test/routes/teams/ios_signing_generate_key_test.dart
@@ -40,6 +40,58 @@ void main() {
   });
 
   group('Generate Key Endpoint', () {
+    test('rejects unsupported methods without creating a key', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/ios-signing/generate-key',
+        method: HttpMethod.get,
+      );
+
+      final response = await generate_key_route.onRequest(
+        context.context,
+        'team-123',
+      );
+
+      expect(response.statusCode, HttpStatus.methodNotAllowed);
+      expect(await db.secretDao.getSecretsForTeam('team-123'), isEmpty);
+    });
+
+    for (final (key, error) in [
+      (null, 'Internal server error'),
+      ('invalid', 'Invalid encryption key configuration'),
+    ]) {
+      test(
+        'does not save a key with invalid encryption config: $key',
+        () async {
+          await db
+              .into(db.teamMembers)
+              .insert(
+                TeamMembersCompanion.insert(
+                  teamId: 'team-123',
+                  userId: 'user-1',
+                ),
+              );
+          final context = TestRequestContext(
+            path: '/teams/team-123/ios-signing/generate-key',
+            method: HttpMethod.post,
+          );
+          context.provide<AppDatabase>(db);
+          context.provide<String?>('user-1');
+          context.provide<Map<String, String>>({
+            'SECRET_ENCRYPTION_KEY': ?key,
+          });
+
+          final response = await generate_key_route.onRequest(
+            context.context,
+            'team-123',
+          );
+
+          expect(response.statusCode, HttpStatus.internalServerError);
+          expect(await response.json(), {'success': false, 'error': error});
+          expect(await db.secretDao.getSecretsForTeam('team-123'), isEmpty);
+        },
+      );
+    }
+
     test('responds with 401 Unauthorized when uid is null', () async {
       final context = TestRequestContext(
         path: '/teams/team-123/ios-signing/generate-key',

--- a/apps/openci_server/test/routes/teams/members_test.dart
+++ b/apps/openci_server/test/routes/teams/members_test.dart
@@ -49,6 +49,89 @@ void main() {
   });
 
   group('members route', () {
+    Future<Response> post({String? uid = 'member-1', String body = '{}'}) {
+      final context = TestRequestContext(
+        path: '/teams/team-123/members',
+        method: HttpMethod.post,
+        body: body,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<FirebaseApp>(mockFirebaseApp);
+      context.provide<String?>(uid);
+      return Future.value(route.onRequest(context.context, 'team-123'));
+    }
+
+    for (final (uid, status) in [(null, 401), ('stranger', 403)]) {
+      test(
+        'POST rejects $uid without contacting Firebase or adding members',
+        () async {
+          final response = await post(
+            uid: uid,
+            body: '{"email":"test@example.com"}',
+          );
+          expect(response.statusCode, status);
+          verifyNever(() => mockAuthService.getUserByEmail(any()));
+          expect(await db.teamDao.getTeamMembers('team-123'), isEmpty);
+        },
+      );
+    }
+
+    for (final body in ['{}', '{"email":"   "}']) {
+      test('POST rejects missing or blank email: $body', () async {
+        await db.teamDao.addTeamMember('team-123', 'member-1');
+        final response = await post(body: body);
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Email is required',
+        });
+        verifyNever(() => mockAuthService.getUserByEmail(any()));
+        expect(await db.teamDao.getTeamMembers('team-123'), hasLength(1));
+      });
+    }
+
+    test(
+      'POST normalizes the email before looking up and adding a member',
+      () async {
+        await db.teamDao.addTeamMember('team-123', 'member-1');
+        final user = MockUserRecord();
+        when(() => user.uid).thenReturn('new-member');
+        when(
+          () => mockAuthService.getUserByEmail('new@example.com'),
+        ).thenAnswer((_) async => user);
+        final response = await post(body: '{"email":"  New@Example.COM  "}');
+        expect(response.statusCode, HttpStatus.ok);
+        expect(await db.teamDao.isTeamMember('new-member', 'team-123'), isTrue);
+        verify(
+          () => mockAuthService.getUserByEmail('new@example.com'),
+        ).called(1);
+      },
+    );
+
+    test(
+      'POST reports a Firebase failure without creating a membership',
+      () async {
+        await db.teamDao.addTeamMember('team-123', 'member-1');
+        when(
+          () => mockAuthService.getUserByEmail(any()),
+        ).thenThrow(StateError('Firebase unavailable'));
+        final response = await post(body: '{"email":"new@example.com"}');
+        expect(response.statusCode, HttpStatus.internalServerError);
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(await db.teamDao.getTeamMembers('team-123'), hasLength(1));
+      },
+    );
+
+    test('rejects unsupported methods', () async {
+      final context = TestRequestContext(
+        path: '/teams/team-123/members',
+        method: HttpMethod.patch,
+      );
+      final response = await route.onRequest(context.context, 'team-123');
+      expect(response.statusCode, HttpStatus.methodNotAllowed);
+    });
+
     test('responds with 401 Unauthorized when uid is null', () async {
       final context = TestRequestContext(
         path: '/teams/team-123/members',

--- a/apps/openci_server/test/routes/teams/secrets_test.dart
+++ b/apps/openci_server/test/routes/teams/secrets_test.dart
@@ -43,6 +43,201 @@ void main() {
     await db.close();
   });
 
+  Future<Response> request({
+    required HttpMethod method,
+    String? name,
+    String? uid = 'user-1',
+    String? body,
+    Map<String, String>? environment,
+    AppDatabase? database,
+  }) async {
+    final context = TestRequestContext(
+      path: '/teams/team-123/secrets${name == null ? '' : '/$name'}',
+      method: method,
+      body: body,
+    );
+    context.provide<AppDatabase>(database ?? db);
+    context.provide<String?>(uid);
+    context.provide<Map<String, String>>(environment ?? env);
+    return name == null
+        ? index_route.onRequest(context.context, 'team-123')
+        : name_route.onRequest(context.context, 'team-123', name);
+  }
+
+  group('secret authorization and failures', () {
+    setUp(() async {
+      await db.teamDao.addTeamMember('team-123', 'user-1');
+      final now = DateTime.now().toUtc();
+      await db.secretDao.insertOrUpdateSecret(
+        DriftSecret(
+          name: 'API_KEY',
+          teamId: 'team-123',
+          encryptedValue: 'stored-ciphertext',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    });
+
+    for (final (method, name) in [
+      (HttpMethod.get, null),
+      (HttpMethod.get, 'API_KEY'),
+      (HttpMethod.delete, 'API_KEY'),
+    ]) {
+      for (final (uid, status) in [
+        (null, HttpStatus.unauthorized),
+        ('stranger', HttpStatus.forbidden),
+      ]) {
+        test(
+          '$method $name rejects $uid without exposing or deleting secrets',
+          () async {
+            final response = await request(
+              method: method,
+              name: name,
+              uid: uid,
+            );
+
+            expect(response.statusCode, status);
+            final body = await response.json() as Map<String, dynamic>;
+            expect(body['success'], isFalse);
+            expect(body, isNot(contains('value')));
+            expect(body, isNot(contains('secrets')));
+            expect(
+              await db.secretDao.getSecret('team-123', 'API_KEY'),
+              isNotNull,
+            );
+          },
+        );
+      }
+    }
+
+    test(
+      'internal processor cannot delete a secret without membership',
+      () async {
+        final response = await request(
+          method: HttpMethod.delete,
+          name: 'API_KEY',
+          uid: 'system-job-processor',
+        );
+        expect(response.statusCode, HttpStatus.forbidden);
+        expect(await db.secretDao.getSecret('team-123', 'API_KEY'), isNotNull);
+      },
+    );
+
+    test(
+      'deleting a missing secret returns 404 and preserves other secrets',
+      () async {
+        final response = await request(
+          method: HttpMethod.delete,
+          name: 'MISSING',
+        );
+        expect(response.statusCode, HttpStatus.notFound);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Secret not found',
+        });
+        expect(await db.secretDao.getSecret('team-123', 'API_KEY'), isNotNull);
+      },
+    );
+
+    for (final name in [null, 'API_KEY']) {
+      test('unsupported method for $name returns 405', () async {
+        final response = await request(method: HttpMethod.patch, name: name);
+        expect(response.statusCode, HttpStatus.methodNotAllowed);
+        expect(await db.secretDao.getSecret('team-123', 'API_KEY'), isNotNull);
+      });
+    }
+
+    for (final payload in [
+      '{',
+      '[]',
+      jsonEncode({'value': 'value'}),
+      jsonEncode({'name': '  ', 'value': 'value'}),
+      jsonEncode({'name': 1, 'value': 'value'}),
+      jsonEncode({'name': 'NEW_SECRET'}),
+      jsonEncode({'name': 'NEW_SECRET', 'value': '  '}),
+      jsonEncode({'name': 'NEW_SECRET', 'value': 1}),
+    ]) {
+      test('invalid payload $payload is rejected before storage', () async {
+        final response = await request(method: HttpMethod.post, body: payload);
+        expect(response.statusCode, HttpStatus.badRequest);
+        final body = await response.json() as Map<String, dynamic>;
+        expect(body['success'], isFalse);
+        expect(body['error'], isNotEmpty);
+        expect(await db.secretDao.getSecretsForTeam('team-123'), hasLength(1));
+      });
+    }
+
+    test(
+      'member can retrieve the decrypted value after updating a secret',
+      () async {
+        final updated = await request(
+          method: HttpMethod.post,
+          body: jsonEncode({'name': ' API_KEY ', 'value': ' new-value '}),
+        );
+        expect(updated.statusCode, HttpStatus.ok);
+        final response = await request(method: HttpMethod.get, name: 'API_KEY');
+        expect(response.statusCode, HttpStatus.ok);
+        expect(await response.json(), {'success': true, 'value': 'new-value'});
+        final stored = await db.secretDao.getSecret('team-123', 'API_KEY');
+        expect(stored!.encryptedValue, isNot('new-value'));
+        expect(await db.secretDao.getSecretsForTeam('team-123'), hasLength(1));
+      },
+    );
+
+    for (final (method, name) in [
+      (HttpMethod.post, null),
+      (HttpMethod.get, 'API_KEY'),
+    ]) {
+      test(
+        '$method rejects an invalid encryption key without changing storage',
+        () async {
+          final response = await request(
+            method: method,
+            name: name,
+            body: jsonEncode({'name': 'API_KEY', 'value': 'replacement'}),
+            environment: {'SECRET_ENCRYPTION_KEY': 'invalid-key'},
+          );
+          expect(response.statusCode, HttpStatus.internalServerError);
+          expect(await response.json(), {
+            'success': false,
+            'error': 'Invalid encryption key configuration',
+          });
+          final stored = await db.secretDao.getSecret('team-123', 'API_KEY');
+          expect(stored!.encryptedValue, 'stored-ciphertext');
+        },
+      );
+    }
+
+    for (final (method, name) in [
+      (HttpMethod.get, null),
+      (HttpMethod.post, null),
+      (HttpMethod.get, 'API_KEY'),
+      (HttpMethod.delete, 'API_KEY'),
+    ]) {
+      test('$method $name hides database failure details', () async {
+        final failingDb = MockAppDatabase();
+        when(() => failingDb.teamDao).thenReturn(db.teamDao);
+        when(
+          () => failingDb.secretDao,
+        ).thenThrow(StateError('private-db-detail'));
+        final response = await request(
+          method: method,
+          name: name,
+          body: jsonEncode({'name': 'API_KEY', 'value': 'replacement'}),
+          database: failingDb,
+        );
+        expect(response.statusCode, HttpStatus.internalServerError);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Internal server error',
+        });
+        final stored = await db.secretDao.getSecret('team-123', 'API_KEY');
+        expect(stored!.encryptedValue, 'stored-ciphertext');
+      });
+    }
+  });
+
   group('Secrets Endpoints', () {
     group('POST /teams/<id>/secrets', () {
       test('responds with 401 Unauthorized when uid is null', () async {

--- a/apps/openci_server/test/routes/teams/workflows_test.dart
+++ b/apps/openci_server/test/routes/teams/workflows_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -68,6 +69,220 @@ void main() {
     await db.close();
     if (tempDir.existsSync()) {
       tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('workflow lookup failures and installations', () {
+    setUp(() => db.teamDao.addTeamMember('team-123', 'user-1'));
+
+    Future<Response> fetch({
+      Object? graphqlBody,
+      int statusCode = 200,
+      http.Client? client,
+      HttpMethod method = HttpMethod.get,
+      String branch = 'feature/builds',
+    }) {
+      final httpClient =
+          client ??
+          MockClient((request) async {
+            if (request.url.path.endsWith('/access_tokens')) {
+              return http.Response(jsonEncode({'token': 'test-token'}), 200);
+            }
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['variables']['expression'], '$branch:.openci');
+            return http.Response(jsonEncode(graphqlBody), statusCode);
+          });
+      addTearDown(httpClient.close);
+      final context = TestRequestContext(
+        path: '/teams/team-123/workflows?repository=owner/repo&branch=$branch',
+        method: method,
+      );
+      context.provide<AppDatabase>(db);
+      context.provide<String?>('user-1');
+      context.provide<Map<String, String>>(testEnv);
+      context.provide<http.Client>(httpClient);
+      return Future.value(
+        workflows_route.onRequest(context.context, 'team-123'),
+      );
+    }
+
+    test('rejects unsupported methods', () async {
+      expect(
+        (await fetch(method: HttpMethod.post)).statusCode,
+        HttpStatus.methodNotAllowed,
+      );
+    });
+
+    test(
+      'reports a missing GitHub installation before making requests',
+      () async {
+        await db
+            .update(db.teams)
+            .write(
+              const TeamsCompanion(installationIds: Value([])),
+            );
+        final response = await fetch(
+          client: MockClient((_) async {
+            fail('No GitHub request should be made without an installation');
+          }),
+        );
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'GitHub App is not installed for this team',
+        });
+      },
+    );
+
+    for (final payload in [
+      {
+        'data': {
+          'repository': {'object': null},
+        },
+      },
+      {
+        'errors': [
+          {'message': 'Could not resolve to an object at this path'},
+        ],
+      },
+    ]) {
+      test(
+        'returns an empty workflow list for a missing tree: $payload',
+        () async {
+          final response = await fetch(graphqlBody: payload);
+          expect(response.statusCode, HttpStatus.ok);
+          expect(await response.json(), {'success': true, 'files': []});
+        },
+      );
+    }
+
+    test('reports a repository absent from all installations', () async {
+      final response = await fetch(
+        graphqlBody: {
+          'data': {'repository': null},
+        },
+      );
+      expect(response.statusCode, HttpStatus.notFound);
+      expect(await response.json(), {
+        'success': false,
+        'error': 'Repository not found in any installation',
+      });
+    });
+
+    for (final (status, payload) in [
+      (503, {'message': 'private upstream detail'}),
+      (
+        200,
+        {
+          'errors': [
+            {'message': 'private upstream detail'},
+          ],
+        },
+      ),
+    ]) {
+      test(
+        'hides upstream failure details for HTTP $status: $payload',
+        () async {
+          final response = await fetch(
+            statusCode: status,
+            graphqlBody: payload,
+          );
+          expect(response.statusCode, HttpStatus.internalServerError);
+          expect(await response.json(), {
+            'success': false,
+            'error': 'Internal server error',
+          });
+        },
+      );
+    }
+
+    test('tries the next installation when the first request fails', () async {
+      await db
+          .update(db.teams)
+          .write(
+            const TeamsCompanion(installationIds: Value([111, 222])),
+          );
+      final tokenPaths = <String>[];
+      var graphRequests = 0;
+      final response = await fetch(
+        client: MockClient((request) async {
+          if (request.url.path.endsWith('/access_tokens')) {
+            tokenPaths.add(request.url.path);
+            return http.Response(jsonEncode({'token': 'test-token'}), 200);
+          }
+          if (++graphRequests == 1) return http.Response('unavailable', 503);
+          return http.Response(
+            jsonEncode({
+              'data': {
+                'repository': {
+                  'object': {
+                    'entries': [
+                      {
+                        'type': 'blob',
+                        'name': 'build.yml',
+                        'object': {'text': 'steps: []'},
+                      },
+                    ],
+                  },
+                },
+              },
+            }),
+            200,
+          );
+        }),
+      );
+      expect(response.statusCode, HttpStatus.ok);
+      expect(tokenPaths, [
+        '/app/installations/111/access_tokens',
+        '/app/installations/222/access_tokens',
+      ]);
+      expect(graphRequests, 2);
+      expect(await response.json(), {
+        'success': true,
+        'files': [
+          {
+            'name': 'build.yml',
+            'path': '.openci/build.yml',
+            'content': 'steps: []',
+          },
+        ],
+      });
+    });
+
+    for (final (baseUrl, graphUrl) in [
+      ('https://github.com/', 'https://api.github.com/graphql'),
+      ('https://github.example.com/', 'https://github.example.com/api/graphql'),
+    ]) {
+      test('uses the GraphQL endpoint for $baseUrl', () async {
+        await db
+            .update(db.teams)
+            .write(
+              TeamsCompanion(githubBaseUrl: Value(baseUrl)),
+            );
+        var queriedGraph = false;
+        final response = await fetch(
+          client: MockClient((request) async {
+            if (request.url.path.endsWith('/access_tokens')) {
+              return http.Response(jsonEncode({'token': 'test-token'}), 200);
+            }
+            queriedGraph = true;
+            expect(request.url.toString(), graphUrl);
+            return http.Response(
+              jsonEncode({
+                'data': {
+                  'repository': {
+                    'object': {'entries': []},
+                  },
+                },
+              }),
+              200,
+            );
+          }),
+        );
+        expect(queriedGraph, isTrue);
+        expect(response.statusCode, HttpStatus.ok);
+        expect(await response.json(), {'success': true, 'files': []});
+      });
     }
   });
 

--- a/apps/openci_server/test/routes/webhook_test.dart
+++ b/apps/openci_server/test/routes/webhook_test.dart
@@ -154,7 +154,8 @@ void main() {
 
     Future<Response> queuePushWebhook({
       required String body,
-      required String deliveryId,
+      String? deliveryId,
+      String eventType = 'push',
     }) {
       final context = TestRequestContext(
         path: '/webhook',
@@ -162,8 +163,8 @@ void main() {
         body: body,
         headers: {
           'x-hub-signature-256': computeSignature(body),
-          'x-github-event': 'push',
-          'x-github-delivery': deliveryId,
+          'x-github-event': eventType,
+          'x-github-delivery': ?deliveryId,
         },
       );
       context.provide<Map<String, String>>({
@@ -178,6 +179,84 @@ void main() {
     });
 
     tearDown(() => db.close());
+
+    for (final deliveryId in [null, '']) {
+      test('rejects a missing or empty delivery ID: $deliveryId', () async {
+        final response = await queuePushWebhook(
+          body: '{}',
+          deliveryId: deliveryId,
+        );
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Missing x-github-delivery header',
+        });
+        expect(await db.select(db.webhookTasks).get(), isEmpty);
+      });
+    }
+
+    for (final event in ['ping', 'issues', '']) {
+      test('acknowledges $event without queuing a task', () async {
+        final response = await queuePushWebhook(
+          body: '{}',
+          deliveryId: 'ignored-event',
+          eventType: event,
+        );
+        expect(response.statusCode, HttpStatus.ok);
+        expect(await response.json(), {
+          'success': true,
+          'message': 'Ignored event type: $event',
+        });
+        expect(await db.select(db.webhookTasks).get(), isEmpty);
+      });
+    }
+
+    for (final action in [
+      'opened',
+      'synchronize',
+      'reopened',
+      'closed',
+      null,
+    ]) {
+      test('filters pull request action $action before queuing', () async {
+        final payload = jsonEncode({'action': action, 'number': 42});
+        final response = await queuePushWebhook(
+          body: payload,
+          deliveryId: 'pr-event',
+          eventType: 'pull_request',
+        );
+        expect(response.statusCode, HttpStatus.ok);
+        final tasks = await db.select(db.webhookTasks).get();
+        if (['opened', 'synchronize', 'reopened'].contains(action)) {
+          expect(tasks, hasLength(1));
+          expect(tasks.single.eventType, 'pull_request');
+          expect(tasks.single.payload, payload);
+          expect(tasks.single.status, 'pending');
+        } else {
+          expect(tasks, isEmpty);
+          expect(await response.json(), {
+            'success': true,
+            'message': 'Ignored pull_request action: $action',
+          });
+        }
+      });
+    }
+
+    for (final payload in ['{', '[]', 'null', '{"action":42}']) {
+      test('rejects a malformed signed PR payload: $payload', () async {
+        final response = await queuePushWebhook(
+          body: payload,
+          deliveryId: 'bad-pr',
+          eventType: 'pull_request',
+        );
+        expect(response.statusCode, HttpStatus.badRequest);
+        expect(await response.json(), {
+          'success': false,
+          'error': 'Invalid JSON body',
+        });
+        expect(await db.select(db.webhookTasks).get(), isEmpty);
+      });
+    }
 
     test('queues a valid webhook delivery', () async {
       const body = '{"ref":"refs/heads/main"}';

--- a/apps/openci_server/test/routes/workers_test.dart
+++ b/apps/openci_server/test/routes/workers_test.dart
@@ -23,6 +23,27 @@ void main() {
 
   group('Workers Route Endpoints', () {
     group('POST /workers/heartbeat', () {
+      for (final payload in ['{', '[]', '{}', '{"workerId":""}']) {
+        test(
+          'rejects malformed heartbeat $payload without recording a worker',
+          () async {
+            final context = TestRequestContext(
+              path: '/workers/heartbeat',
+              method: HttpMethod.post,
+              body: payload,
+            );
+            context.provide<AppDatabase>(db);
+            context.provide<String?>('worker-1');
+            final response = await heartbeat_route.onRequest(context.context);
+            expect(response.statusCode, HttpStatus.badRequest);
+            final body = await response.json() as Map<String, dynamic>;
+            expect(body['success'], isFalse);
+            expect(body['error'], isNotEmpty);
+            expect(await db.workerHeartbeatDao.getAllHeartbeats(), isEmpty);
+          },
+        );
+      }
+
       test('responds with 401 Unauthorized when uid is null', () async {
         final context = TestRequestContext(
           path: '/workers/heartbeat',

--- a/apps/openci_server/test/team/team_mapper_test.dart
+++ b/apps/openci_server/test/team/team_mapper_test.dart
@@ -1,0 +1,40 @@
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/team/team_mapper.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  for (final githubBaseUrl in [null, 'https://github.example.com']) {
+    test(
+      'team database round trip preserves settings for $githubBaseUrl',
+      () async {
+        final db = AppDatabase(NativeDatabase.memory());
+        addTearDown(db.close);
+        final team = Team(
+          id: 'team-1',
+          name: '開発チーム',
+          members: ['user-1'],
+          installationIds: [123, 456],
+          githubBaseUrl: githubBaseUrl,
+          aiEnabled: false,
+          runNumber: 42,
+          createdAt: DateTime.utc(2026, 1, 1),
+          updatedAt: DateTime.utc(2026, 2, 1),
+        );
+
+        await db.teamDao.createTeamAndMember(team.toDrift(), 'user-1');
+        final stored = await db.teamDao.getTeam(team.id);
+        final members = await db.teamDao.getTeamMembers(team.id);
+
+        expect(stored, isNotNull);
+        expect(
+          stored!
+              .toShared(members: members.map((m) => m.userId).toList())
+              .toJson(),
+          team.toJson(),
+        );
+      },
+    );
+  }
+}

--- a/apps/openci_server/test/webhook_task/webhook_task_mapper_test.dart
+++ b/apps/openci_server/test/webhook_task/webhook_task_mapper_test.dart
@@ -1,0 +1,33 @@
+import 'package:drift/native.dart';
+import 'package:openci_server/database.dart';
+import 'package:openci_server/webhook_task/webhook_task_mapper.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  for (final errorMessage in [null, 'upstream unavailable']) {
+    test(
+      'webhook task database round trip preserves retry state: $errorMessage',
+      () async {
+        final db = AppDatabase(NativeDatabase.memory());
+        addTearDown(db.close);
+        final task = WebhookTask(
+          id: 'task-1',
+          deliveryId: 'delivery-1',
+          eventType: 'pull_request',
+          payload: '{"action":"opened","title":"ビルド"}',
+          status: errorMessage == null ? 'pending' : 'failed',
+          retryCount: errorMessage == null ? 0 : 3,
+          errorMessage: errorMessage,
+          createdAt: DateTime.utc(2026, 1, 1),
+          updatedAt: DateTime.utc(2026, 2, 1),
+        );
+
+        await db.webhookTaskDao.insertWebhookTask(task.toDrift());
+        final stored = await db.select(db.webhookTasks).getSingle();
+
+        expect(stored.toShared().toJson(), task.toJson());
+      },
+    );
+  }
+}


### PR DESCRIPTION
…hook handling

- Implement tests for team members route to validate member addition, email normalization, and error handling.
- Enhance secrets route tests to cover authorization, invalid payloads, and database failure scenarios.
- Introduce workflow lookup failure tests to ensure proper error handling and response for GitHub installations.
- Expand webhook tests to validate delivery ID handling, event filtering, and malformed payload rejection.
- Add heartbeat route tests to ensure proper handling of malformed requests without recording workers.
- Create new tests for database failure scenarios to ensure internal server errors are handled gracefully.
- Implement team and webhook task mapper tests to verify database round-trip integrity for team settings and webhook task states.