### PR TITLE
feat: report build job worker errors to Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,4 @@ BUILD_JOB_WORKER_STOP_GRACE_PERIOD=1h
 # Sentry configurations
 SENTRY_DSN_SERVER=your-sentry-dsn-for-server-here
 SENTRY_DSN_BUILD_JOB_PLANNER=your-sentry-dsn-for-build-job-planner-here
+SENTRY_DSN_BUILD_JOB_WORKER=

--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -21,7 +21,7 @@ Composeでは`build-job-worker`を常駐サービスとして起動します。
 - `ORCHARD_API_URL`: 任意。デフォルトは`https://orchard-controller:6120`。
 - `LOKI_URL`: 任意。workerからのログ送信先。デフォルトは`http://loki:3100`。
 - `LOKI_URL_FOR_VM`: 任意。VMからのログ送信先。デフォルトは`http://192.168.64.1:3100`。
-- `SENTRY_DSN`: 任意。現段階では読み込みのみで、Sentryへの接続は行いません。
+- `SENTRY_DSN`: 任意。設定するとworker内部の例外をSentryへ送信します。未設定・空文字列の場合は送信しません。
 
 必須設定が未指定または空文字列の場合は、変数名を標準エラー出力へ出して
 終了コード1で終了します。認証キーやトークンの値は出力しません。
@@ -122,6 +122,7 @@ jobがない場合と、取得・実行関数が例外を投げた場合は、`p
 
 ルートの`.env.example`を参考に、`.env`とserver用の認証ファイルを準備します。
 Orchardのサービスアカウント名とAPI用トークンは`.env`へ設定してください。
+Sentryへの通知を有効にする場合は、`.env`の`SENTRY_DSN_BUILD_JOB_WORKER`を設定します。
 macOS側のOrchard workerとTartの`base-macos`も準備済みの状態で、リポジトリルートから実行します。
 既存環境から切り替える場合は、更新前の構成でjobの取得を止め、実行中のjobが完了してからworkerを起動してください。
 
@@ -150,7 +151,8 @@ LOKI_URL=http://localhost:3100 \
 dart run bin/main.dart
 ```
 
-起動後はjobを継続して取得します。取得・実行中の例外は標準エラー出力へ記録します。
+起動後はjobを継続して取得します。起動・取得・実行・結果保存・VM削除などの例外は標準エラー出力へ記録し、DSN設定時はSentryにも送信します。
+Sentryへの送信はjobの処理を待たせずに行い、worker終了時に送信完了を最大5秒待ってからSentryを閉じます。送信の失敗でjobの結果は変更しません。
 `SIGTERM`または`SIGINT`（Ctrl+C）で新しいjobの取得を止め、取得済みjobの結果保存・VM削除を試みてからクライアントを閉じます。
 空キューの待機中なら最大3秒、job取得・実行中ならその処理が終わるまで待ちます。
 停止シグナルによる正常終了は終了コード0、設定・起動に失敗した場合は終了コード1です。
@@ -181,5 +183,4 @@ docker build -f apps/build_job_worker/Dockerfile -t openci-build-job-worker .
 
 - 実行中jobのキャンセル監視。
 - VM準備に失敗した場合の自動リトライ。
-- Sentryへのエラー通知。
 - VM準備・checkout・ワークフロー全体の進捗イベント送信。

--- a/apps/build_job_worker/bin/main.dart
+++ b/apps/build_job_worker/bin/main.dart
@@ -3,7 +3,11 @@ import 'dart:io';
 
 import 'package:build_job_worker/build_job_worker.dart';
 import 'package:http/http.dart' as http;
+import 'package:openci_shared/initialize_sentry.dart';
 import 'package:openci_shared/openci_shared.dart';
+import 'package:sentry/sentry.dart';
+
+final _pendingErrorReports = <Future<void>>{};
 
 Future<void> main() async {
   final Config config;
@@ -16,11 +20,22 @@ Future<void> main() async {
   }
 
   try {
+    await initializeSentry(config.sentryDsn);
     await _runWorker(config);
     stdout.writeln('Build job worker stopped.');
   } catch (error, stackTrace) {
     _reportError(error, stackTrace);
     exitCode = 1;
+  } finally {
+    try {
+      await Future.wait(
+        _pendingErrorReports,
+      ).timeout(const Duration(seconds: 5));
+    } on TimeoutException {
+      stderr.writeln('Timed out sending worker errors to Sentry.');
+    } finally {
+      await Sentry.close();
+    }
   }
 }
 
@@ -80,4 +95,15 @@ Future<void> _runWorker(Config config) async {
 void _reportError(Object error, StackTrace stackTrace) {
   stderr.writeln('Build job worker error: $error');
   stderr.writeln(stackTrace);
+  if (!Sentry.isEnabled) return;
+
+  final report = Sentry.captureException(error, stackTrace: stackTrace)
+      .then<void>(
+        (_) {},
+        onError: (Object _, StackTrace _) {
+          stderr.writeln('Failed to send worker error to Sentry.');
+        },
+      );
+  _pendingErrorReports.add(report);
+  unawaited(report.whenComplete(() => _pendingErrorReports.remove(report)));
 }

--- a/apps/build_job_worker/integration_test/startup_test.dart
+++ b/apps/build_job_worker/integration_test/startup_test.dart
@@ -36,6 +36,7 @@ void main() {
         final worker = await _startWorker({
           ...environment,
           'OPENCI_SERVER_URL': _url(server),
+          'SENTRY_DSN': '',
         });
 
         await claimed.future.timeout(_waitTimeout);
@@ -57,8 +58,13 @@ void main() {
     );
   }
 
-  test('reports claim errors and continues polling', () async {
+  test('keeps polling when Sentry rejects errors', () async {
     final nextClaim = Completer<HttpRequest>();
+    final reports = <Map<String, dynamic>>[];
+    final sentry = await _serve((request) async {
+      reports.add(await _sentryEvent(request));
+      await _reply(request, null, statusCode: 503);
+    });
     var claims = 0;
     final server = await _serve((request) async {
       expect(request.uri.path, '/builds/claim');
@@ -72,6 +78,7 @@ void main() {
     final worker = await _startWorker({
       ...environment,
       'OPENCI_SERVER_URL': _url(server),
+      'SENTRY_DSN': _sentryDsn(sentry),
     });
 
     final request = await nextClaim.future.timeout(_waitTimeout);
@@ -85,14 +92,19 @@ void main() {
     expect(result.stderr, contains('HTTP 503'));
     expect(result.stderr, contains('claimNextBuildJob'));
     expect(claims, 2);
+    _expectSentryException(reports.single, 'StateError', 'HTTP 503');
     _expectNoCredentials(result, environment);
   }, skip: Platform.isWindows);
 
   test(
-    'finishes a job claimed during shutdown and reports execution errors',
+    'finishes a job claimed during shutdown and waits for its Sentry report',
     () async {
       final claim = Completer<HttpRequest>();
       final completed = <String>[];
+      final report = Completer<(HttpRequest, Map<String, dynamic>)>();
+      final sentry = await _serve((request) async {
+        report.complete((request, await _sentryEvent(request)));
+      });
       final server = await _serve((request) async {
         final path = request.uri.path;
         final body = await _body(request);
@@ -117,12 +129,21 @@ void main() {
       final worker = await _startWorker({
         ...environment,
         'OPENCI_SERVER_URL': _url(server),
+        'SENTRY_DSN': _sentryDsn(sentry),
       });
 
       final request = await claim.future.timeout(_waitTimeout);
       expect(worker.process.kill(ProcessSignal.sigint), isTrue);
       await worker.waitForOutput('Waiting for the current job to finish.');
       await _reply(request, {'job': _job().toJson()});
+      final (sentryRequest, event) = await report.future.timeout(_waitTimeout);
+      await worker.waitForOutput('Build job worker stopped.');
+      await expectLater(
+        worker.exited.timeout(const Duration(milliseconds: 100)),
+        throwsA(isA<TimeoutException>()),
+      );
+      _expectSentryException(event, 'StateError', 'Failed to create build run');
+      await _reply(sentryRequest, {});
       final result = await worker.finish();
 
       expect(result.exitCode, 0);
@@ -332,16 +353,47 @@ void main() {
 
   for (final key in ['OPENCI_SERVER_URL', 'ORCHARD_API_URL']) {
     test('exits with an error if $key prevents client creation', () async {
-      final worker = await _startWorker({...environment, key: 'http://['});
+      final reports = <Map<String, dynamic>>[];
+      final sentry = await _serve((request) async {
+        reports.add(await _sentryEvent(request));
+        await _reply(request, {});
+      });
+      final worker = await _startWorker({
+        ...environment,
+        key: 'http://[',
+        'SENTRY_DSN': _sentryDsn(sentry),
+      });
       final result = await worker.finish();
 
       expect(result.exitCode, 1);
       expect(result.stdout, isEmpty);
       expect(result.stderr, contains('Build job worker error:'));
       expect(result.stderr, contains('FormatException'));
+      _expectSentryException(reports.single, 'FormatException', 'http://[');
       _expectNoCredentials(result, environment);
     });
   }
+
+  test('stops when Sentry does not respond', () async {
+    final reports = <Map<String, dynamic>>[];
+    final sentry = await _serve((request) async {
+      reports.add(await _sentryEvent(request));
+    });
+    final worker = await _startWorker({
+      ...environment,
+      'ORCHARD_API_URL': 'http://[',
+      'SENTRY_DSN': _sentryDsn(sentry),
+    });
+    final result = await worker.finish();
+
+    expect(result.exitCode, 1);
+    expect(
+      result.stderr,
+      contains('Timed out sending worker errors to Sentry.'),
+    );
+    _expectSentryException(reports.single, 'FormatException', 'http://[');
+    _expectNoCredentials(result, environment);
+  });
 }
 
 Future<_WorkerProcess> _startWorker(Map<String, String> environment) async {
@@ -425,6 +477,35 @@ Future<HttpServer> _serve(Future<void> Function(HttpRequest) handler) async {
 }
 
 String _url(HttpServer server) => 'http://127.0.0.1:${server.port}';
+
+String _sentryDsn(HttpServer server) =>
+    'http://public@127.0.0.1:${server.port}/1';
+
+Future<Map<String, dynamic>> _sentryEvent(HttpRequest request) async {
+  expect(request.method, 'POST');
+  expect(request.uri.path, '/api/1/envelope/');
+  var bytes = await request.fold(<int>[], (body, chunk) => body..addAll(chunk));
+  if (request.headers.value(HttpHeaders.contentEncodingHeader) == 'gzip') {
+    bytes = gzip.decode(bytes);
+  }
+  final lines = const LineSplitter().convert(utf8.decode(bytes));
+  expect(jsonDecode(lines[1]), containsPair('type', 'event'));
+  return jsonDecode(lines[2]) as Map<String, dynamic>;
+}
+
+void _expectSentryException(
+  Map<String, dynamic> event,
+  String type,
+  String message,
+) {
+  final exceptions = event['exception'] as Map<String, dynamic>;
+  final exception =
+      (exceptions['values'] as List<dynamic>).single as Map<String, dynamic>;
+  expect(exception['type'], type);
+  expect(exception['value'], contains(message));
+  final stackTrace = exception['stacktrace'] as Map<String, dynamic>;
+  expect(stackTrace['frames'], isNotEmpty);
+}
 
 Future<Map<String, dynamic>> _body(HttpRequest request) async =>
     jsonDecode(await utf8.decoder.bind(request).join()) as Map<String, dynamic>;

--- a/apps/build_job_worker/pubspec.yaml
+++ b/apps/build_job_worker/pubspec.yaml
@@ -11,6 +11,7 @@ resolution: workspace
 dependencies:
   http: ^1.6.0
   openci_shared: ^1.0.1
+  sentry: ^9.22.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       ORCHARD_VM_MEMORY_GB: ${ORCHARD_VM_MEMORY_GB:-4}
       LOKI_URL: http://loki:3100
       LOKI_URL_FOR_VM: ${LOKI_URL_FOR_VM:-http://192.168.64.1:3100}
+      SENTRY_DSN: ${SENTRY_DSN_BUILD_JOB_WORKER:-}
     depends_on:
       server:
         condition: service_healthy


### PR DESCRIPTION
worker内部の例外が標準エラー出力にしか残らなかったため、既存の`initializeSentry()`と`onError`を接続しました。Composeの`SENTRY_DSN_BUILD_JOB_WORKER`を設定すると、起動・job取得・実行・終了処理の例外をスタックトレース付きで送信します。未設定・空文字列でもworkerは起動できます。

送信はjob処理と並行して行い、終了時に未完了の送信を最大5秒待ってからSentryを閉じます。送信失敗でjobの結果は変更しません。

検証済み:

- workerのformat、`dart analyze --fatal-infos`、unit・起動テスト285件。
- ローカル受信サーバーで例外とスタックトレース、送信失敗後のポーリング継続、終了時の送信待ち、無応答時の停止を確認。
- Compose設定の検証と、DSN未設定・設定時の引き渡しを確認。
- workerのDockerイメージビルド、差分全体のレビュー、`git diff --check`。

実際のSentryサービスへの送信は未確認です。有効にする環境ではDSNの設定が必要です。
