### PR TITLE
feat: report VM preparation progress from build job worker

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -100,12 +100,14 @@ stdout・stderrは`step_id: run_workflow`でLokiへ送り、送信待ちが終�
 
 `executeBuildJob(api: api, orchardApi: orchardApi, lokiClient: lokiClient, config: config, job: job, onError: onError)`は、claim済みの`IN_PROGRESS`のjobを1件実行します。
 run IDとVM名を生成し、run作成、GitHubトークン取得、VM準備、checkout、secrets取得、ワークフロー実行を順に行います。
+VM準備は`prepare_vm`（表示名`Set up VM`）として、開始時に`IN_PROGRESS`、終了時に`SUCCESS`または`FAILURE`と処理時間をLokiへ送信します。既存のビルド画面で状態と所要時間を確認できます。
+進捗イベントの送信は1件あたり最大10秒待ち、失敗してもjobの実行結果やVM削除の処理は変えません。
 終了コード0なら`SUCCESS`、それ以外や実行途中の例外なら`FAILURE`として、run・job・GitHub Checksに結果の保存を試みます。
 run作成が失敗した場合はrunの完了更新とVM作成を行わず、job・GitHub Checksの失敗記録を試みます。
 VM準備に成功した場合は`finally`でVMの削除を試みます。起動待ち中の失敗は`prepareVm()`が削除を担当します。
 結果保存とVM削除はそれぞれ失敗しても後続処理を続け、1処理の待ち時間は`finalizationTimeout`（標準10秒）で制限します。自動再送は行いません。
 返り値は実行結果の`BuildJobStatus`です。結果保存やVM削除の失敗によって、この実行結果は変更しません。
-ログ送信の失敗は発生時に、それ以外の例外は終了処理を試みた後に`onError`へ通知します。このコールバックは例外を投げずに記録してください。
+コマンド出力の送信失敗は発生時に、進捗送信などそれ以外の例外は終了処理を試みた後に`onError`へ通知します。このコールバックは例外を投げずに記録してください。
 クライアントの生成・共有・終了処理は呼び出し元で行います。キャンセル監視、job全体のタイムアウトはまだ行いません。
 
 `runBuildJobWorker(api: api, executeJob: executeJob, shouldStop: shouldStop, onError: onError)`は、jobの取得と実行を順番に繰り返します。
@@ -183,4 +185,4 @@ docker build -f apps/build_job_worker/Dockerfile -t openci-build-job-worker .
 
 - 実行中jobのキャンセル監視。
 - VM準備に失敗した場合の自動リトライ。
-- VM準備・checkout・ワークフロー全体の進捗イベント送信。
+- checkout・ワークフロー全体の進捗イベント送信。

--- a/apps/build_job_worker/integration_test/startup_test.dart
+++ b/apps/build_job_worker/integration_test/startup_test.dart
@@ -303,10 +303,32 @@ void main() {
           'status': 'completed',
           'conclusion': conclusion,
         });
-        expect(logs, hasLength(2));
-        for (var index = 0; index < logs.length; index++) {
+        expect(logs, hasLength(4));
+        for (final (index, log) in logs.take(2).indexed) {
           final stream =
-              (logs[index]['streams'] as List<dynamic>).single
+              (log['streams'] as List<dynamic>).single as Map<String, dynamic>;
+          expect(stream['stream'], {
+            'stream': 'stdout',
+            'type': 'step_event',
+            'run_id': runId,
+            'build_job_id': 'job-1',
+            'step_id': 'prepare_vm',
+          });
+          final values =
+              (stream['values'] as List<dynamic>).single as List<dynamic>;
+          final step = BuildStep.fromJson(
+            jsonDecode(values[1] as String) as Map<String, dynamic>,
+          );
+          expect(step.runId, runId);
+          expect(
+            step.status,
+            index == 0 ? BuildJobStatus.IN_PROGRESS : BuildJobStatus.SUCCESS,
+          );
+        }
+        final outputLogs = logs.skip(2).toList();
+        for (var index = 0; index < outputLogs.length; index++) {
+          final stream =
+              (outputLogs[index]['streams'] as List<dynamic>).single
                   as Map<String, dynamic>;
           expect(stream['stream'], {
             'stream': 'stdout',

--- a/apps/build_job_worker/lib/src/execute_build_job.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:http/http.dart' as http;
@@ -10,6 +11,7 @@ import 'complete_github_check_run.dart';
 import 'config.dart';
 import 'create_build_run.dart';
 import 'fetch_job_secrets.dart';
+import 'loki/push_log_to_loki.dart';
 import 'orchard/orchard_api_client.dart';
 import 'orchard/prepare_vm.dart';
 import 'resolve_github_installation_token.dart';
@@ -49,16 +51,58 @@ Future<BuildJobStatus> executeBuildJob({
   String? leaseId;
   final errors = <(Object, StackTrace)>[];
 
+  Future<void> reportVmStep(BuildStep step) async {
+    try {
+      await pushLogToLoki(
+        client: lokiClient,
+        lokiUrl: config.internalLokiUrl,
+        runId: runId,
+        jobId: job.id,
+        stepId: step.id,
+        type: 'step_event',
+        message: jsonEncode(step.toJson()),
+      ).timeout(const Duration(seconds: 10));
+    } catch (error, stackTrace) {
+      errors.add((error, stackTrace));
+    }
+  }
+
   try {
     await createBuildRun(api: api, jobId: job.id, runId: runId);
     runCreated = true;
     final token = await resolveGitHubInstallationToken(api: api, jobId: job.id);
-    final lease = await prepareVm(
-      api: orchardApi,
-      baseVmName: config.baseVmName,
-      vmName: vmName,
+    final startedAt = DateTime.now().toUtc();
+    final vmStep = BuildStep(
+      id: 'prepare_vm',
+      runId: runId,
+      name: 'Set up VM',
+      status: BuildJobStatus.IN_PROGRESS,
+      durationMs: 0,
+      stepOrder: 0,
+      createdAt: startedAt,
+      updatedAt: startedAt,
     );
-    leaseId = lease.id.isNotEmpty ? lease.id : vmName;
+    await reportVmStep(vmStep);
+    final stopwatch = Stopwatch()..start();
+    try {
+      final lease = await prepareVm(
+        api: orchardApi,
+        baseVmName: config.baseVmName,
+        vmName: vmName,
+      );
+      leaseId = lease.id.isNotEmpty ? lease.id : vmName;
+    } finally {
+      stopwatch.stop();
+      await reportVmStep(
+        vmStep.copyWith(
+          status: leaseId == null
+              ? BuildJobStatus.FAILURE
+              : BuildJobStatus.SUCCESS,
+          durationMs: stopwatch.elapsedMilliseconds,
+          updatedAt: DateTime.now().toUtc(),
+        ),
+      );
+    }
 
     await checkoutRepository(
       api: orchardApi,

--- a/apps/build_job_worker/test/src/execute_build_job_test.dart
+++ b/apps/build_job_worker/test/src/execute_build_job_test.dart
@@ -93,6 +93,21 @@ void main() {
     );
   }
 
+  List<BuildStep> vmSteps() => logRequests
+      .map(_lokiStream)
+      .where((stream) {
+        final labels = stream['stream'] as Map<String, dynamic>;
+        return labels['type'] == 'step_event';
+      })
+      .map((stream) {
+        final values =
+            (stream['values'] as List<dynamic>).single as List<dynamic>;
+        return BuildStep.fromJson(
+          jsonDecode(values[1] as String) as Map<String, dynamic>,
+        );
+      })
+      .toList();
+
   setUpAll(() {
     registerFallbackValue((String line, String stream) {});
   });
@@ -116,6 +131,10 @@ void main() {
     respondToLog = (_) async => http.Response('', 204);
     lokiClient = _TrackingClient((request) {
       logRequests.add(request);
+      final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
+      if (labels['type'] == 'step_event') {
+        events.add('vmStep:${vmSteps().last.status.name}');
+      }
       return respondToLog(request);
     });
     final now = DateTime.utc(2026, 9, 7);
@@ -243,8 +262,10 @@ void main() {
         expect(events, [
           'createRun',
           'token',
+          'vmStep:IN_PROGRESS',
           'createVm',
           'waitVm',
+          'vmStep:SUCCESS',
           'writeCheckout',
           'checkout',
           'secrets',
@@ -283,8 +304,31 @@ void main() {
         expect(deletedVms, ['lease-1']);
         expect(errors, isEmpty);
 
-        expect(logRequests, hasLength(2));
-        for (final (index, step) in ['checkout', 'run_workflow'].indexed) {
+        final steps = vmSteps();
+        expect(steps.map((step) => step.status), [
+          BuildJobStatus.IN_PROGRESS,
+          BuildJobStatus.SUCCESS,
+        ]);
+        for (final step in steps) {
+          expect(step.id, 'prepare_vm');
+          expect(step.runId, runIds.single);
+          expect(step.name, 'Set up VM');
+          expect(step.stepOrder, 0);
+          expect(step.createdAt.isUtc, isTrue);
+          expect(step.updatedAt.isUtc, isTrue);
+        }
+        expect(steps.first.durationMs, 0);
+        expect(steps.last.durationMs, greaterThanOrEqualTo(0));
+        expect(steps.last.createdAt, steps.first.createdAt);
+        expect(steps.last.updatedAt.isBefore(steps.first.updatedAt), isFalse);
+
+        expect(logRequests, hasLength(4));
+        for (final (index, step) in [
+          'prepare_vm',
+          'prepare_vm',
+          'checkout',
+          'run_workflow',
+        ].indexed) {
           final request = logRequests[index];
           expect(
             request.url.toString(),
@@ -297,6 +341,42 @@ void main() {
           expect(stream['stream'], containsPair('build_job_id', job.id));
           expect(stream['stream'], containsPair('step_id', step));
         }
+      },
+    );
+
+    test(
+      'reports progress during VM preparation and measures its duration',
+      () async {
+        final started = Completer<void>();
+        final finish = Completer<void>();
+        addTearDown(() {
+          if (!finish.isCompleted) finish.complete();
+        });
+        when(
+          () => orchardApi.waitForVmRunning(
+            'lease-1',
+            timeout: const Duration(minutes: 15),
+          ),
+        ).thenAnswer((_) async {
+          started.complete();
+          await finish.future;
+          return OrchardLease(
+            id: leaseId,
+            vmName: vmNames.single,
+            status: 'running',
+          );
+        });
+
+        final result = execute();
+        await started.future;
+        expect(vmSteps().single.status, BuildJobStatus.IN_PROGRESS);
+        expect(commands, isEmpty);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        finish.complete();
+
+        expect(await result, BuildJobStatus.SUCCESS);
+        expect(vmSteps().last.status, BuildJobStatus.SUCCESS);
+        expect(vmSteps().last.durationMs, greaterThanOrEqualTo(10));
       },
     );
 
@@ -365,6 +445,14 @@ void main() {
         expect(await execute(), BuildJobStatus.FAILURE);
 
         expectCompletion(BuildJobStatus.FAILURE, hasRun: stage != 'createRun');
+        expect(vmSteps().map((step) => step.status), [
+          if (!['createRun', 'token'].contains(stage)) ...[
+            BuildJobStatus.IN_PROGRESS,
+            ['createVm', 'waitVm'].contains(stage)
+                ? BuildJobStatus.FAILURE
+                : BuildJobStatus.SUCCESS,
+          ],
+        ]);
         expect(errors, hasLength(1));
         expect(errors.single.$2.toString(), sourceStack.toString());
         expect(events.where((event) => event == stage), hasLength(1));
@@ -499,17 +587,52 @@ void main() {
       expect(await execute(), BuildJobStatus.SUCCESS);
 
       expectCompletion(BuildJobStatus.SUCCESS);
-      expect(errors, hasLength(2));
+      expect(errors, hasLength(4));
       expect(deletedVms, ['lease-1']);
     });
+
+    test('preserves VM failure when progress delivery also fails', () async {
+      final vmError = failures['waitVm'] = StateError('VM failed');
+      respondToLog = (_) async => http.Response('', 503);
+
+      expect(await execute(), BuildJobStatus.FAILURE);
+
+      expectCompletion(BuildJobStatus.FAILURE);
+      expect(vmSteps().last.status, BuildJobStatus.FAILURE);
+      expect(errors, hasLength(3));
+      expect(errors.last.$1, same(vmError));
+      expect(errors.last.$2.toString(), sourceStack.toString());
+      expect(deletedVms, ['lease-1']);
+    });
+
+    test(
+      'continues after a progress timeout and handles a late failure',
+      () async {
+        final response = Completer<http.Response>();
+        respondToLog = (_) => logRequests.length == 1
+            ? response.future
+            : Future.value(http.Response('', 204));
+
+        expect(await execute(), BuildJobStatus.SUCCESS);
+
+        expectCompletion(BuildJobStatus.SUCCESS);
+        expect(deletedVms, ['lease-1']);
+        expect(errors.single.$1, isA<TimeoutException>());
+        expect(vmSteps().last.status, BuildJobStatus.SUCCESS);
+        response.completeError(StateError('Late progress failure'));
+        await Future<void>.delayed(Duration.zero);
+        expect(errors, hasLength(1));
+      },
+    );
 
     test(
       'waits for workflow log delivery before finalizing and deleting the VM',
       () async {
         final started = Completer<void>();
         final response = Completer<http.Response>();
-        respondToLog = (_) {
-          if (logRequests.length == 1) {
+        respondToLog = (request) {
+          final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
+          if (labels['step_id'] != 'run_workflow') {
             return Future.value(http.Response('', 204));
           }
           started.complete();
@@ -543,4 +666,9 @@ void main() {
       },
     );
   });
+}
+
+Map<String, dynamic> _lokiStream(http.Request request) {
+  final body = jsonDecode(request.body) as Map<String, dynamic>;
+  return (body['streams'] as List<dynamic>).single as Map<String, dynamic>;
 }


### PR DESCRIPTION
VM準備中の状態がビルド画面のステップに表示されなかったため、`executeBuildJob()`から`prepare_vm`（Set up VM）の進捗イベントをLokiへ送信します。開始時に`IN_PROGRESS`、終了時に`SUCCESS`または`FAILURE`とVM準備の処理時間を記録し、既存のステップ表示で読み取れる`BuildStep`形式を使います。

送信待ちは1件あたり最大10秒です。通知の失敗によってjobの結果を変えず、結果保存とVM削除を試みた後に`onError`へ通知します。VM準備が失敗した場合も、元の例外とスタックトレースを保持します。

検証済み:

- workerのformat、`dart analyze --fatal-infos`、unit・起動テスト288件。
- VM起動待ち中の進捗、成功・失敗の状態、所要時間、既存画面が使う`BuildStep`への変換を確認。
- 通知失敗・タイムアウト・遅れて発生する送信エラーが、jobの結果保存とVM削除を妨げないことを確認。
- workerのDockerイメージビルド、差分全体のレビュー、`git diff --check`。

受信の検証にはローカルのHTTPサーバーを使用しました。実VMと画面を使った動作確認は未実施です。
