### PR TITLE
feat: report checkout progress from build job worker

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -101,6 +101,7 @@ stdout・stderrは`step_id: run_workflow`でLokiへ送り、送信待ちが終�
 `executeBuildJob(api: api, orchardApi: orchardApi, lokiClient: lokiClient, config: config, job: job, onError: onError)`は、claim済みの`IN_PROGRESS`のjobを1件実行します。
 run IDとVM名を生成し、run作成、GitHubトークン取得、VM準備、checkout、secrets取得、ワークフロー実行を順に行います。
 VM準備は`prepare_vm`（表示名`Set up VM`）として、開始時に`IN_PROGRESS`、終了時に`SUCCESS`または`FAILURE`と処理時間をLokiへ送信します。既存のビルド画面で状態と所要時間を確認できます。
+checkoutも`checkout`（表示名`Checkout Repository`）として同じ進捗を送信し、VM準備の次に表示します。既存のcheckoutログをこのステップから確認できます。
 進捗イベントの送信は1件あたり最大10秒待ち、失敗してもjobの実行結果やVM削除の処理は変えません。
 終了コード0なら`SUCCESS`、それ以外や実行途中の例外なら`FAILURE`として、run・job・GitHub Checksに結果の保存を試みます。
 run作成が失敗した場合はrunの完了更新とVM作成を行わず、job・GitHub Checksの失敗記録を試みます。
@@ -185,4 +186,4 @@ docker build -f apps/build_job_worker/Dockerfile -t openci-build-job-worker .
 
 - 実行中jobのキャンセル監視。
 - VM準備に失敗した場合の自動リトライ。
-- checkout・ワークフロー全体の進捗イベント送信。
+- ワークフロー全体の進捗イベント送信。

--- a/apps/build_job_worker/integration_test/startup_test.dart
+++ b/apps/build_job_worker/integration_test/startup_test.dart
@@ -303,16 +303,29 @@ void main() {
           'status': 'completed',
           'conclusion': conclusion,
         });
-        expect(logs, hasLength(4));
-        for (final (index, log) in logs.take(2).indexed) {
-          final stream =
-              (log['streams'] as List<dynamic>).single as Map<String, dynamic>;
+        expect(logs, hasLength(6));
+        final streams = logs
+            .map(
+              (log) =>
+                  (log['streams'] as List<dynamic>).single
+                      as Map<String, dynamic>,
+            )
+            .toList();
+        final stepEvents = streams
+            .where(
+              (stream) =>
+                  (stream['stream'] as Map<String, dynamic>)['type'] ==
+                  'step_event',
+            )
+            .toList();
+        expect(stepEvents, hasLength(4));
+        for (final (index, stream) in stepEvents.indexed) {
           expect(stream['stream'], {
             'stream': 'stdout',
             'type': 'step_event',
             'run_id': runId,
             'build_job_id': 'job-1',
-            'step_id': 'prepare_vm',
+            'step_id': index < 2 ? 'prepare_vm' : 'checkout',
           });
           final values =
               (stream['values'] as List<dynamic>).single as List<dynamic>;
@@ -322,14 +335,19 @@ void main() {
           expect(step.runId, runId);
           expect(
             step.status,
-            index == 0 ? BuildJobStatus.IN_PROGRESS : BuildJobStatus.SUCCESS,
+            index.isEven ? BuildJobStatus.IN_PROGRESS : BuildJobStatus.SUCCESS,
           );
         }
-        final outputLogs = logs.skip(2).toList();
+        final outputLogs = streams
+            .where(
+              (stream) =>
+                  (stream['stream'] as Map<String, dynamic>)['type'] ==
+                  'step_log',
+            )
+            .toList();
+        expect(outputLogs, hasLength(2));
         for (var index = 0; index < outputLogs.length; index++) {
-          final stream =
-              (outputLogs[index]['streams'] as List<dynamic>).single
-                  as Map<String, dynamic>;
+          final stream = outputLogs[index];
           expect(stream['stream'], {
             'stream': 'stdout',
             'type': 'step_log',

--- a/apps/build_job_worker/lib/src/execute_build_job.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job.dart
@@ -51,7 +51,7 @@ Future<BuildJobStatus> executeBuildJob({
   String? leaseId;
   final errors = <(Object, StackTrace)>[];
 
-  Future<void> reportVmStep(BuildStep step) async {
+  Future<void> reportStep(BuildStep step) async {
     try {
       await pushLogToLoki(
         client: lokiClient,
@@ -82,7 +82,7 @@ Future<BuildJobStatus> executeBuildJob({
       createdAt: startedAt,
       updatedAt: startedAt,
     );
-    await reportVmStep(vmStep);
+    await reportStep(vmStep);
     final stopwatch = Stopwatch()..start();
     try {
       final lease = await prepareVm(
@@ -93,7 +93,7 @@ Future<BuildJobStatus> executeBuildJob({
       leaseId = lease.id.isNotEmpty ? lease.id : vmName;
     } finally {
       stopwatch.stop();
-      await reportVmStep(
+      await reportStep(
         vmStep.copyWith(
           status: leaseId == null
               ? BuildJobStatus.FAILURE
@@ -104,16 +104,44 @@ Future<BuildJobStatus> executeBuildJob({
       );
     }
 
-    await checkoutRepository(
-      api: orchardApi,
-      lokiClient: lokiClient,
-      lokiUrl: config.internalLokiUrl,
-      vmName: vmName,
-      job: job,
-      token: token,
+    final checkoutStartedAt = DateTime.now().toUtc();
+    final checkoutStep = BuildStep(
+      id: 'checkout',
       runId: runId,
-      onLogError: onError,
+      name: 'Checkout Repository',
+      status: BuildJobStatus.IN_PROGRESS,
+      durationMs: 0,
+      stepOrder: 1,
+      createdAt: checkoutStartedAt,
+      updatedAt: checkoutStartedAt,
     );
+    await reportStep(checkoutStep);
+    final checkoutStopwatch = Stopwatch()..start();
+    var checkoutSucceeded = false;
+    try {
+      await checkoutRepository(
+        api: orchardApi,
+        lokiClient: lokiClient,
+        lokiUrl: config.internalLokiUrl,
+        vmName: vmName,
+        job: job,
+        token: token,
+        runId: runId,
+        onLogError: onError,
+      );
+      checkoutSucceeded = true;
+    } finally {
+      checkoutStopwatch.stop();
+      await reportStep(
+        checkoutStep.copyWith(
+          status: checkoutSucceeded
+              ? BuildJobStatus.SUCCESS
+              : BuildJobStatus.FAILURE,
+          durationMs: checkoutStopwatch.elapsedMilliseconds,
+          updatedAt: DateTime.now().toUtc(),
+        ),
+      );
+    }
     final secretsContent = await fetchJobSecrets(api: api, jobId: job.id);
     final exitCode = await runWorkflow(
       api: orchardApi,

--- a/apps/build_job_worker/test/src/execute_build_job_test.dart
+++ b/apps/build_job_worker/test/src/execute_build_job_test.dart
@@ -93,11 +93,11 @@ void main() {
     );
   }
 
-  List<BuildStep> vmSteps() => logRequests
+  List<BuildStep> stepEvents(String stepId) => logRequests
       .map(_lokiStream)
       .where((stream) {
         final labels = stream['stream'] as Map<String, dynamic>;
-        return labels['type'] == 'step_event';
+        return labels['type'] == 'step_event' && labels['step_id'] == stepId;
       })
       .map((stream) {
         final values =
@@ -133,7 +133,8 @@ void main() {
       logRequests.add(request);
       final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
       if (labels['type'] == 'step_event') {
-        events.add('vmStep:${vmSteps().last.status.name}');
+        final stepId = labels['step_id'] as String;
+        events.add('$stepId:${stepEvents(stepId).last.status.name}');
       }
       return respondToLog(request);
     });
@@ -262,12 +263,14 @@ void main() {
         expect(events, [
           'createRun',
           'token',
-          'vmStep:IN_PROGRESS',
+          'prepare_vm:IN_PROGRESS',
           'createVm',
           'waitVm',
-          'vmStep:SUCCESS',
+          'prepare_vm:SUCCESS',
+          'checkout:IN_PROGRESS',
           'writeCheckout',
           'checkout',
+          'checkout:SUCCESS',
           'secrets',
           'writeSecrets',
           'writeWorkflow',
@@ -304,7 +307,7 @@ void main() {
         expect(deletedVms, ['lease-1']);
         expect(errors, isEmpty);
 
-        final steps = vmSteps();
+        final steps = stepEvents('prepare_vm');
         expect(steps.map((step) => step.status), [
           BuildJobStatus.IN_PROGRESS,
           BuildJobStatus.SUCCESS,
@@ -322,10 +325,12 @@ void main() {
         expect(steps.last.createdAt, steps.first.createdAt);
         expect(steps.last.updatedAt.isBefore(steps.first.updatedAt), isFalse);
 
-        expect(logRequests, hasLength(4));
+        expect(logRequests, hasLength(6));
         for (final (index, step) in [
           'prepare_vm',
           'prepare_vm',
+          'checkout',
+          'checkout',
           'checkout',
           'run_workflow',
         ].indexed) {
@@ -369,16 +374,59 @@ void main() {
 
         final result = execute();
         await started.future;
-        expect(vmSteps().single.status, BuildJobStatus.IN_PROGRESS);
+        expect(
+          stepEvents('prepare_vm').single.status,
+          BuildJobStatus.IN_PROGRESS,
+        );
         expect(commands, isEmpty);
         await Future<void>.delayed(const Duration(milliseconds: 20));
         finish.complete();
 
         expect(await result, BuildJobStatus.SUCCESS);
-        expect(vmSteps().last.status, BuildJobStatus.SUCCESS);
-        expect(vmSteps().last.durationMs, greaterThanOrEqualTo(10));
+        expect(stepEvents('prepare_vm').last.status, BuildJobStatus.SUCCESS);
+        expect(
+          stepEvents('prepare_vm').last.durationMs,
+          greaterThanOrEqualTo(10),
+        );
       },
     );
+
+    test('reports checkout progress and duration', () async {
+      final started = Completer<void>();
+      final finish = pending['checkout'] = Completer<void>();
+      addTearDown(() {
+        if (!finish.isCompleted) finish.complete();
+      });
+      respondToLog = (request) async {
+        final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
+        if (labels['type'] == 'step_log' && labels['step_id'] == 'checkout') {
+          started.complete();
+        }
+        return http.Response('', 204);
+      };
+
+      final result = execute();
+      await started.future;
+      final inProgress = stepEvents('checkout').single;
+      expect(inProgress.status, BuildJobStatus.IN_PROGRESS);
+      expect(inProgress.id, 'checkout');
+      expect(inProgress.runId, runIds.single);
+      expect(inProgress.name, 'Checkout Repository');
+      expect(inProgress.stepOrder, 1);
+      expect(inProgress.durationMs, 0);
+      expect(inProgress.createdAt.isUtc, isTrue);
+      expect(inProgress.updatedAt, inProgress.createdAt);
+      expect(events, isNot(contains('workflow')));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      finish.complete();
+
+      expect(await result, BuildJobStatus.SUCCESS);
+      final completed = stepEvents('checkout').last;
+      expect(completed.status, BuildJobStatus.SUCCESS);
+      expect(completed.createdAt, inProgress.createdAt);
+      expect(completed.updatedAt.isBefore(inProgress.updatedAt), isFalse);
+      expect(completed.durationMs, greaterThanOrEqualTo(10));
+    });
 
     test(
       'records a nonzero workflow exit code as failure and cleans up',
@@ -388,6 +436,7 @@ void main() {
         expect(await execute(), BuildJobStatus.FAILURE);
 
         expectCompletion(BuildJobStatus.FAILURE);
+        expect(stepEvents('checkout').last.status, BuildJobStatus.SUCCESS);
         expect(deletedVms, ['lease-1']);
         expect(errors, isEmpty);
       },
@@ -445,10 +494,23 @@ void main() {
         expect(await execute(), BuildJobStatus.FAILURE);
 
         expectCompletion(BuildJobStatus.FAILURE, hasRun: stage != 'createRun');
-        expect(vmSteps().map((step) => step.status), [
+        expect(stepEvents('prepare_vm').map((step) => step.status), [
           if (!['createRun', 'token'].contains(stage)) ...[
             BuildJobStatus.IN_PROGRESS,
             ['createVm', 'waitVm'].contains(stage)
+                ? BuildJobStatus.FAILURE
+                : BuildJobStatus.SUCCESS,
+          ],
+        ]);
+        expect(stepEvents('checkout').map((step) => step.status), [
+          if (![
+            'createRun',
+            'token',
+            'createVm',
+            'waitVm',
+          ].contains(stage)) ...[
+            BuildJobStatus.IN_PROGRESS,
+            ['writeCheckout', 'checkout'].contains(stage)
                 ? BuildJobStatus.FAILURE
                 : BuildJobStatus.SUCCESS,
           ],
@@ -587,7 +649,7 @@ void main() {
       expect(await execute(), BuildJobStatus.SUCCESS);
 
       expectCompletion(BuildJobStatus.SUCCESS);
-      expect(errors, hasLength(4));
+      expect(errors, hasLength(6));
       expect(deletedVms, ['lease-1']);
     });
 
@@ -598,32 +660,62 @@ void main() {
       expect(await execute(), BuildJobStatus.FAILURE);
 
       expectCompletion(BuildJobStatus.FAILURE);
-      expect(vmSteps().last.status, BuildJobStatus.FAILURE);
+      expect(stepEvents('prepare_vm').last.status, BuildJobStatus.FAILURE);
       expect(errors, hasLength(3));
       expect(errors.last.$1, same(vmError));
       expect(errors.last.$2.toString(), sourceStack.toString());
       expect(deletedVms, ['lease-1']);
     });
 
-    test(
-      'continues after a progress timeout and handles a late failure',
-      () async {
+    test('preserves checkout failure when progress delivery fails', () async {
+      final checkoutError = failures['checkout'] = StateError(
+        'Checkout failed',
+      );
+      respondToLog = (request) async {
+        final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
+        return http.Response(
+          '',
+          labels['type'] == 'step_event' && labels['step_id'] == 'checkout'
+              ? 503
+              : 204,
+        );
+      };
+
+      expect(await execute(), BuildJobStatus.FAILURE);
+
+      expectCompletion(BuildJobStatus.FAILURE);
+      expect(stepEvents('checkout').last.status, BuildJobStatus.FAILURE);
+      expect(events, isNot(contains('workflow')));
+      expect(errors, hasLength(3));
+      expect(errors.last.$1, same(checkoutError));
+      expect(errors.last.$2.toString(), sourceStack.toString());
+      expect(deletedVms, ['lease-1']);
+    });
+
+    for (final stepId in ['prepare_vm', 'checkout']) {
+      test('continues after $stepId progress times out', () async {
         final response = Completer<http.Response>();
-        respondToLog = (_) => logRequests.length == 1
-            ? response.future
-            : Future.value(http.Response('', 204));
+        respondToLog = (request) {
+          final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
+          if (labels['type'] == 'step_event' &&
+              labels['step_id'] == stepId &&
+              stepEvents(stepId).last.status == BuildJobStatus.IN_PROGRESS) {
+            return response.future;
+          }
+          return Future.value(http.Response('', 204));
+        };
 
         expect(await execute(), BuildJobStatus.SUCCESS);
 
         expectCompletion(BuildJobStatus.SUCCESS);
         expect(deletedVms, ['lease-1']);
         expect(errors.single.$1, isA<TimeoutException>());
-        expect(vmSteps().last.status, BuildJobStatus.SUCCESS);
+        expect(stepEvents(stepId).last.status, BuildJobStatus.SUCCESS);
         response.completeError(StateError('Late progress failure'));
         await Future<void>.delayed(Duration.zero);
         expect(errors, hasLength(1));
-      },
-    );
+      });
+    }
 
     test(
       'waits for workflow log delivery before finalizing and deleting the VM',


### PR DESCRIPTION
checkoutの開始・終了状態がビルド画面のステップに表示されなかったため、VM準備で使っている進捗通知を共用して、`checkout`（Checkout Repository）の開始・成功・失敗と所要時間をLokiへ送信します。VM準備の次に表示し、既存のcheckoutログと同じステップIDを使います。

checkoutの結果を独立して記録するため、後続のワークフローが失敗してもcheckoutの成功状態は保持します。通知待ちは1件あたり最大10秒で、通知の失敗によってjobの結果保存やVM削除を妨げません。

検証済み:

- workerのformat、`dart analyze --fatal-infos`、unit・起動テスト291件。
- checkout中の進捗、成功・失敗時の状態、所要時間、既存画面が使う`BuildStep`への変換を確認。
- 通知の失敗・タイムアウト・遅れて発生した送信エラーの後も、元の実行結果と例外を保持し、結果保存・VM削除を続けることを確認。
- workerのDockerイメージビルド、差分全体のレビュー、`git diff --check`。

受信の検証にはローカルのHTTPサーバーを使用しました。実VMと画面を使った動作確認は未実施です。
