### PR TITLE
fix: honor Compose configuration in dev start

### DIFF
--- a/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
@@ -33,14 +33,7 @@ Future<bool> startDockerCompose(
 }) async {
   logger.stdout('\n${t.dev.start.stepDockerCompose}');
 
-  final parentEnvironment = environment ?? Platform.environment;
-  final composeEnvironment = {
-    ...parentEnvironment,
-    'BASE_VM_NAME': parentEnvironment['BASE_VM_NAME'] ?? 'base-macos',
-    'INTERNAL_API_KEY':
-        parentEnvironment['INTERNAL_API_KEY'] ?? 'genuineci-local-dev-key',
-    'ORCHARD_API_URL': 'https://orchard-controller:6120',
-  };
+  final composeEnvironment = environment ?? Platform.environment;
 
   try {
     final exitCode = await processRunner(

--- a/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
@@ -108,6 +108,35 @@ void main() {
       expect(capturedEnvironment, {'PATH': '/usr/local/bin'});
     });
 
+    test(
+      'inherits the process environment when no override is given',
+      () async {
+        late Map<String, String> capturedEnvironment;
+
+        final result = await startDockerCompose(
+          logger,
+          projectRoot,
+          processRunner:
+              (_, _, {required workingDirectory, required environment}) async {
+                capturedEnvironment = environment;
+                return 0;
+              },
+        );
+
+        expect(result, isTrue);
+        expect(
+          capturedEnvironment.keys,
+          unorderedEquals(Platform.environment.keys),
+        );
+        expect(
+          capturedEnvironment.entries.every(
+            (entry) => entry.value == Platform.environment[entry.key],
+          ),
+          isTrue,
+        );
+      },
+    );
+
     test('returns false when Docker Compose exits with an error', () async {
       const dockerComposeFailureExitCode = 17;
 

--- a/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
@@ -41,7 +41,8 @@ void main() {
         environment: const {
           'PATH': '/usr/local/bin',
           'BASE_VM_NAME': 'custom-base',
-          'ORCHARD_API_URL': 'https://ignored.example.com',
+          'INTERNAL_API_KEY': 'custom-api-key',
+          'ORCHARD_API_URL': 'https://custom-orchard.example.com',
         },
         processRunner:
             (
@@ -76,8 +77,8 @@ void main() {
       expect(capturedEnvironment, {
         'PATH': '/usr/local/bin',
         'BASE_VM_NAME': 'custom-base',
-        'ORCHARD_API_URL': 'https://orchard-controller:6120',
-        'INTERNAL_API_KEY': 'genuineci-local-dev-key',
+        'INTERNAL_API_KEY': 'custom-api-key',
+        'ORCHARD_API_URL': 'https://custom-orchard.example.com',
       });
       expect(logger.stderrMessages, isEmpty);
       expect(
@@ -87,6 +88,24 @@ void main() {
           t.dev.start.stepDockerComposeStarted,
         ]),
       );
+    });
+
+    test('leaves unset configuration to Compose and its .env file', () async {
+      late Map<String, String> capturedEnvironment;
+
+      final result = await startDockerCompose(
+        logger,
+        projectRoot,
+        environment: const {'PATH': '/usr/local/bin'},
+        processRunner:
+            (_, _, {required workingDirectory, required environment}) async {
+              capturedEnvironment = environment;
+              return 0;
+            },
+      );
+
+      expect(result, isTrue);
+      expect(capturedEnvironment, {'PATH': '/usr/local/bin'});
     });
 
     test('returns false when Docker Compose exits with an error', () async {


### PR DESCRIPTION
`genuineci dev start` overrode Compose configuration with a fallback internal API key and VM name, and a fixed Orchard URL. This shadowed `.env` settings; requests using the configured internal API key returned HTTP 401 after startup.

Pass the process environment through unchanged so Compose resolves shell overrides, `.env` values, and its existing defaults. Add regression coverage for the default process environment, explicitly configured values, and variables left unset for Compose.

Validation:
- `dart format --output=none --set-exit-if-changed apps/genuineci_cli`: passed.
- `flutter analyze --no-pub apps/genuineci_cli` and `flutter test --coverage --no-pub`: all 92 CLI tests passed. Local LCOV confirms the changed production line is covered.
- Ran the installed, repository-linked `genuineci dev start`: exited 0 and started all six Compose services, with server and PostgreSQL healthy.
- Confirmed server, planner, and worker use the `.env` internal API key; the same authenticated request changed from HTTP 401 to HTTP 200. Orchard accepted the worker's configured credentials. The `.env` file was unchanged.
- Reviewed the complete two-file diff and ran `git diff --check`.

This verification covers startup and API connectivity. It does not execute a VM job or use `--seed`; the host Orchard worker, real seed workflow, and GitHub Check creation remain separate follow-ups.
