### PR TITLE
feat: run local Orchard worker from dev start

### DIFF
--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -26,7 +26,7 @@
   "dev": {
     "description": "Manage local development environment (Docker, Tart, DB, Server).",
     "start": {
-      "description": "Start local development environment (Docker containers, Tart VM, Orchard).",
+      "description": "Start local services and run the Mac Orchard Worker until Ctrl+C.",
       "flags": {
         "seed": "Seed local test data after starting services."
       },
@@ -42,6 +42,8 @@
       "stepOrchardContext": "Step 4: Registering Orchard CLI context...",
       "stepOrchardContextFailed": "Error: Failed to register Orchard CLI context.",
       "stepOrchardContextRegistered": "Orchard CLI context authenticated.",
+      "stepOrchardWorker": "Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.",
+      "stepOrchardWorkerFailed": "Error: Orchard Worker could not start or exited with an error.",
       "stepSeed": "Step 5: Seeding local test data...",
       "stepSeedFailed": "Error: Failed to seed local test data.",
       "stepSeedCompleted": "Local test data seeded.",

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -26,7 +26,7 @@
   "dev": {
     "description": "ローカル開発環境（Docker, Tart, DB, サーバー）を管理します。",
     "start": {
-      "description": "ローカル開発環境（Docker コンテナ、Tart VM、Orchard）を起動します。",
+      "description": "ローカルサービスを起動し、Ctrl+CまでMac側のOrchard Workerを実行します。",
       "flags": {
         "seed": "サービス起動後にローカルテストデータを投入します。"
       },
@@ -42,6 +42,8 @@
       "stepOrchardContext": "Step 4: Orchard CLI コンテキストを登録中...",
       "stepOrchardContextFailed": "エラー: Orchard CLI コンテキストの登録に失敗しました。",
       "stepOrchardContextRegistered": "Orchard CLI コンテキストを認証しました。",
+      "stepOrchardWorker": "Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。",
+      "stepOrchardWorkerFailed": "エラー: Orchard Workerを起動できなかったか、異常終了しました。",
       "stepSeed": "Step 5: ローカルテストデータを投入中...",
       "stepSeedFailed": "エラー: ローカルテストデータの投入に失敗しました。",
       "stepSeedCompleted": "ローカルテストデータを投入しました。",

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -10,6 +10,7 @@ import 'find_project_root.dart';
 import 'seed_local_data.dart';
 import 'setup_orchard_context.dart';
 import 'start_docker_compose.dart';
+import 'start_orchard_worker.dart';
 
 typedef ProjectRootFinder = Directory? Function();
 typedef TartBaseImageChecker = Future<bool> Function(Logger logger);
@@ -17,6 +18,7 @@ typedef DockerComposeStarter =
     Future<bool> Function(Logger logger, Directory projectRoot);
 typedef OrchardContextSetup = Future<bool> Function(Logger logger);
 typedef LocalDataSeeder = Future<bool> Function(Logger logger);
+typedef OrchardWorkerStarter = Future<int> Function(Logger logger);
 
 class DevStartCommand extends Command<int> {
   @override
@@ -31,6 +33,7 @@ class DevStartCommand extends Command<int> {
   final DockerComposeStarter _dockerComposeStarter;
   final OrchardContextSetup _orchardContextSetup;
   final LocalDataSeeder _localDataSeeder;
+  final OrchardWorkerStarter _orchardWorkerStarter;
 
   DevStartCommand({
     required Logger logger,
@@ -42,12 +45,15 @@ class DevStartCommand extends Command<int> {
     @visibleForTesting
     OrchardContextSetup orchardContextSetup = setupOrchardContext,
     @visibleForTesting LocalDataSeeder localDataSeeder = seedLocalData,
+    @visibleForTesting
+    OrchardWorkerStarter orchardWorkerStarter = startOrchardWorker,
   }) : _logger = logger,
        _projectRootFinder = projectRootFinder,
        _tartBaseImageChecker = tartBaseImageChecker,
        _dockerComposeStarter = dockerComposeStarter,
        _orchardContextSetup = orchardContextSetup,
-       _localDataSeeder = localDataSeeder {
+       _localDataSeeder = localDataSeeder,
+       _orchardWorkerStarter = orchardWorkerStarter {
     argParser.addFlag('seed', negatable: false, help: t.dev.start.flags.seed);
   }
 
@@ -87,6 +93,6 @@ class DevStartCommand extends Command<int> {
       }
     }
 
-    return 0;
+    return _orchardWorkerStarter(_logger);
   }
 }

--- a/apps/genuineci_cli/lib/src/commands/dev/start_orchard_worker.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_orchard_worker.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:meta/meta.dart';
+
+import '../../i18n/i18n.dart';
+import 'setup_orchard_context.dart';
+
+typedef OrchardWorkerProcessStarter =
+    Future<Process> Function(
+      String executable,
+      List<String> arguments, {
+      required ProcessStartMode mode,
+    });
+
+Future<int> startOrchardWorker(
+  Logger logger, {
+  @visibleForTesting OrchardProcessRunner processRunner = Process.run,
+  @visibleForTesting OrchardWorkerProcessStarter processStarter = Process.start,
+  @visibleForTesting Stream<ProcessSignal>? interruptSignals,
+  @visibleForTesting Stream<ProcessSignal>? terminateSignals,
+}) async {
+  try {
+    final tokenResult = await processRunner('orchard', [
+      'get',
+      'bootstrap-token',
+      'bootstrap-admin',
+    ]);
+    final token = tokenResult.stdout.toString().trim();
+    if (tokenResult.exitCode != 0 || token.isEmpty) {
+      logger.stderr(t.dev.start.stepOrchardWorkerFailed);
+      return 1;
+    }
+
+    logger.stdout('\n${t.dev.start.stepOrchardWorker}');
+    final process = await processStarter('orchard', [
+      'worker',
+      'run',
+      'https://127.0.0.1:6120',
+      '--bootstrap-token',
+      token,
+      '--no-pki',
+    ], mode: ProcessStartMode.inheritStdio);
+
+    ProcessSignal? stopSignal;
+    void stop(ProcessSignal signal) {
+      stopSignal ??= signal;
+      // Orchard handles SIGINT by shutting down its worker.
+      process.kill(ProcessSignal.sigint);
+    }
+
+    final interruptSubscription =
+        (interruptSignals ?? ProcessSignal.sigint.watch()).listen(stop);
+    final terminateSubscription =
+        (terminateSignals ?? ProcessSignal.sigterm.watch()).listen(stop);
+    try {
+      final exitCode = await process.exitCode;
+      if (stopSignal != null) {
+        return 128 + stopSignal!.signalNumber;
+      }
+      if (exitCode != 0) {
+        logger.stderr(t.dev.start.stepOrchardWorkerFailed);
+      }
+      return exitCode < 0 ? 128 - exitCode : exitCode;
+    } finally {
+      await interruptSubscription.cancel();
+      await terminateSubscription.cancel();
+    }
+  } on ProcessException catch (error) {
+    logger.stderr('${t.dev.start.stepOrchardWorkerFailed}\n${error.message}');
+    return 1;
+  }
+}

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 68 (34 per locale)
+/// Strings: 72 (36 per locale)
 ///
-/// Built on 2026-09-02 at 17:14 UTC
+/// Built on 2026-09-08 at 09:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -166,8 +166,8 @@ class Translations$dev$start$en {
 
 	// Translations
 
-	/// en: 'Start local development environment (Docker containers, Tart VM, Orchard).'
-	String get description => 'Start local development environment (Docker containers, Tart VM, Orchard).';
+	/// en: 'Start local services and run the Mac Orchard Worker until Ctrl+C.'
+	String get description => 'Start local services and run the Mac Orchard Worker until Ctrl+C.';
 
 	late final Translations$dev$start$flags$en flags = Translations$dev$start$flags$en.internal(_root);
 
@@ -206,6 +206,12 @@ class Translations$dev$start$en {
 
 	/// en: 'Orchard CLI context authenticated.'
 	String get stepOrchardContextRegistered => 'Orchard CLI context authenticated.';
+
+	/// en: 'Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.'
+	String get stepOrchardWorker => 'Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.';
+
+	/// en: 'Error: Orchard Worker could not start or exited with an error.'
+	String get stepOrchardWorkerFailed => 'Error: Orchard Worker could not start or exited with an error.';
 
 	/// en: 'Step 5: Seeding local test data...'
 	String get stepSeed => 'Step 5: Seeding local test data...';
@@ -255,7 +261,7 @@ extension on Translations {
 			'use.success' => ({required Object language}) => 'Language set to ${language}.',
 			'use.invalidLanguage' => ({required Object input}) => 'Invalid language "${input}". Supported languages: japanese, english.',
 			'dev.description' => 'Manage local development environment (Docker, Tart, DB, Server).',
-			'dev.start.description' => 'Start local development environment (Docker containers, Tart VM, Orchard).',
+			'dev.start.description' => 'Start local services and run the Mac Orchard Worker until Ctrl+C.',
 			'dev.start.flags.seed' => 'Seed local test data after starting services.',
 			'dev.start.starting' => 'Starting OpenCI Local Development Environment...',
 			'dev.start.stepTart' => 'Step 1: Checking Tart VM base image...',
@@ -269,6 +275,8 @@ extension on Translations {
 			'dev.start.stepOrchardContext' => 'Step 4: Registering Orchard CLI context...',
 			'dev.start.stepOrchardContextFailed' => 'Error: Failed to register Orchard CLI context.',
 			'dev.start.stepOrchardContextRegistered' => 'Orchard CLI context authenticated.',
+			'dev.start.stepOrchardWorker' => 'Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.',
+			'dev.start.stepOrchardWorkerFailed' => 'Error: Orchard Worker could not start or exited with an error.',
 			'dev.start.stepSeed' => 'Step 5: Seeding local test data...',
 			'dev.start.stepSeedFailed' => 'Error: Failed to seed local test data.',
 			'dev.start.stepSeedCompleted' => 'Local test data seeded.',

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -134,7 +134,7 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	final TranslationsJa _root; // ignore: unused_field
 
 	// Translations
-	@override String get description => 'ローカル開発環境（Docker コンテナ、Tart VM、Orchard）を起動します。';
+	@override String get description => 'ローカルサービスを起動し、Ctrl+CまでMac側のOrchard Workerを実行します。';
 	@override late final _Translations$dev$start$flags$ja flags = _Translations$dev$start$flags$ja._(_root);
 	@override String get starting => 'OpenCI ローカル開発環境を起動しています...';
 	@override String get stepTart => 'Step 1: Tart VM ベースイメージを確認中...';
@@ -148,6 +148,8 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepOrchardContext => 'Step 4: Orchard CLI コンテキストを登録中...';
 	@override String get stepOrchardContextFailed => 'エラー: Orchard CLI コンテキストの登録に失敗しました。';
 	@override String get stepOrchardContextRegistered => 'Orchard CLI コンテキストを認証しました。';
+	@override String get stepOrchardWorker => 'Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。';
+	@override String get stepOrchardWorkerFailed => 'エラー: Orchard Workerを起動できなかったか、異常終了しました。';
 	@override String get stepSeed => 'Step 5: ローカルテストデータを投入中...';
 	@override String get stepSeedFailed => 'エラー: ローカルテストデータの投入に失敗しました。';
 	@override String get stepSeedCompleted => 'ローカルテストデータを投入しました。';
@@ -187,7 +189,7 @@ extension on TranslationsJa {
 			'use.success' => ({required Object language}) => '言語を${language}に設定しました。',
 			'use.invalidLanguage' => ({required Object input}) => '無効な言語です: 「${input}」。対応言語: japanese, english',
 			'dev.description' => 'ローカル開発環境（Docker, Tart, DB, サーバー）を管理します。',
-			'dev.start.description' => 'ローカル開発環境（Docker コンテナ、Tart VM、Orchard）を起動します。',
+			'dev.start.description' => 'ローカルサービスを起動し、Ctrl+CまでMac側のOrchard Workerを実行します。',
 			'dev.start.flags.seed' => 'サービス起動後にローカルテストデータを投入します。',
 			'dev.start.starting' => 'OpenCI ローカル開発環境を起動しています...',
 			'dev.start.stepTart' => 'Step 1: Tart VM ベースイメージを確認中...',
@@ -201,6 +203,8 @@ extension on TranslationsJa {
 			'dev.start.stepOrchardContext' => 'Step 4: Orchard CLI コンテキストを登録中...',
 			'dev.start.stepOrchardContextFailed' => 'エラー: Orchard CLI コンテキストの登録に失敗しました。',
 			'dev.start.stepOrchardContextRegistered' => 'Orchard CLI コンテキストを認証しました。',
+			'dev.start.stepOrchardWorker' => 'Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。',
+			'dev.start.stepOrchardWorkerFailed' => 'エラー: Orchard Workerを起動できなかったか、異常終了しました。',
 			'dev.start.stepSeed' => 'Step 5: ローカルテストデータを投入中...',
 			'dev.start.stepSeedFailed' => 'エラー: ローカルテストデータの投入に失敗しました。',
 			'dev.start.stepSeedCompleted' => 'ローカルテストデータを投入しました。',

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -41,6 +41,7 @@ void main() {
     required bool shouldSeed,
     required bool seedSucceeds,
     required void Function() onSeed,
+    OrchardWorkerStarter? orchardWorkerStarter,
   }) {
     final runner = CommandRunner<int>('genuineci', 'CLI tool')
       ..addCommand(
@@ -54,6 +55,7 @@ void main() {
             onSeed();
             return seedSucceeds;
           },
+          orchardWorkerStarter: orchardWorkerStarter ?? (_) async => 0,
         ),
       );
 
@@ -111,9 +113,62 @@ void main() {
       shouldSeed: true,
       seedSucceeds: false,
       onSeed: () => seedCallCount++,
+      orchardWorkerStarter: (_) async => fail('Worker must not start'),
     );
 
     expect(result, equals(1));
     expect(seedCallCount, equals(1));
   });
+
+  for (final shouldSeed in [false, true]) {
+    test('runs the worker after setup with seed=$shouldSeed', () async {
+      final calls = <String>[];
+      bool recordStep(String step) {
+        calls.add(step);
+        return true;
+      }
+
+      final logger = _RecordingLogger();
+      final runner = CommandRunner<int>('genuineci', 'CLI tool')
+        ..addCommand(
+          DevStartCommand(
+            logger: logger,
+            projectRootFinder: () => tempDirectory,
+            tartBaseImageChecker: (_) async => recordStep('tart'),
+            dockerComposeStarter: (_, _) async => recordStep('compose'),
+            orchardContextSetup: (_) async => recordStep('context'),
+            localDataSeeder: (_) async => recordStep('seed'),
+            orchardWorkerStarter: (workerLogger) async {
+              expect(workerLogger, same(logger));
+              calls.add('worker');
+              return 17;
+            },
+          ),
+        );
+
+      expect(await runner.run(['start', if (shouldSeed) '--seed']), 17);
+      expect(calls, [
+        'tart',
+        'compose',
+        'context',
+        if (shouldSeed) 'seed',
+        'worker',
+      ]);
+    });
+  }
+
+  for (final failingStep in ['tart', 'compose', 'context']) {
+    test('does not start the worker when $failingStep fails', () async {
+      final result = await DevStartCommand(
+        logger: _RecordingLogger(),
+        projectRootFinder: () => tempDirectory,
+        tartBaseImageChecker: (_) async => failingStep != 'tart',
+        dockerComposeStarter: (_, _) async => failingStep != 'compose',
+        orchardContextSetup: (_) async => failingStep != 'context',
+        orchardWorkerStarter: (_) async => fail('Worker must not start'),
+      ).run();
+
+      expect(result, 1);
+    });
+  }
 }

--- a/apps/genuineci_cli/test/src/commands/dev/start_orchard_worker_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_orchard_worker_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:genuineci_cli/src/commands/dev/start_orchard_worker.dart';
+import 'package:genuineci_cli/src/i18n/i18n.dart';
+import 'package:test/test.dart';
+
+class _RecordingLogger implements Logger {
+  final stdoutMessages = <String>[];
+  final stderrMessages = <String>[];
+
+  @override
+  void stdout(String message) => stdoutMessages.add(message);
+
+  @override
+  void stderr(String message) => stderrMessages.add(message);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _WorkerProcess implements Process {
+  final exited = Completer<int>();
+  final signals = <ProcessSignal>[];
+
+  @override
+  Future<int> get exitCode => exited.future;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    signals.add(signal);
+    return true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _RecordingLogger logger;
+  late _WorkerProcess worker;
+  const token = 'test-bootstrap-token';
+
+  setUp(() {
+    logger = _RecordingLogger();
+    worker = _WorkerProcess();
+  });
+
+  test(
+    'runs the local worker with terminal output and waits for exit',
+    () async {
+      final calls = <List<String>>[];
+      final started = Completer<void>();
+      var completed = false;
+
+      final result =
+          startOrchardWorker(
+            logger,
+            processRunner: (executable, arguments) async {
+              calls.add([executable, ...arguments]);
+              return ProcessResult(1, 0, '$token\n', '');
+            },
+            processStarter: (executable, arguments, {required mode}) async {
+              calls.add([executable, ...arguments]);
+              expect(mode, ProcessStartMode.inheritStdio);
+              started.complete();
+              return worker;
+            },
+          ).then((code) {
+            completed = true;
+            return code;
+          });
+      await started.future;
+      expect(completed, isFalse);
+      worker.exited.complete(0);
+
+      expect(await result, 0);
+      expect(calls, [
+        ['orchard', 'get', 'bootstrap-token', 'bootstrap-admin'],
+        [
+          'orchard',
+          'worker',
+          'run',
+          'https://127.0.0.1:6120',
+          '--bootstrap-token',
+          token,
+          '--no-pki',
+        ],
+      ]);
+      expect(logger.stdoutMessages, ['\n${t.dev.start.stepOrchardWorker}']);
+      expect(logger.stderrMessages, isEmpty);
+    },
+  );
+
+  for (final code in [17, -9]) {
+    test('reports worker exit $code as a shell exit code', () async {
+      worker.exited.complete(code);
+      final result = await startOrchardWorker(
+        logger,
+        processRunner: (_, _) async => ProcessResult(1, 0, token, ''),
+        processStarter: (_, _, {required mode}) async => worker,
+      );
+
+      expect(result, code == 17 ? 17 : 137);
+      expect(logger.stderrMessages, [t.dev.start.stepOrchardWorkerFailed]);
+    });
+  }
+
+  for (final tokenResult in [
+    ProcessResult(1, 1, token, 'private error'),
+    ProcessResult(1, 0, ' \n', ''),
+  ]) {
+    test(
+      'rejects a token result with exit code ${tokenResult.exitCode}',
+      () async {
+        final result = await startOrchardWorker(
+          logger,
+          processRunner: (_, _) async => tokenResult,
+          processStarter: (_, _, {required mode}) async =>
+              fail('Worker must not start'),
+        );
+
+        expect(result, 1);
+        expect(logger.stdoutMessages, isEmpty);
+        expect(logger.stderrMessages, [t.dev.start.stepOrchardWorkerFailed]);
+      },
+    );
+  }
+
+  for (final failTokenCommand in [true, false]) {
+    test(
+      'reports a process failure (token command: $failTokenCommand)',
+      () async {
+        final result = await startOrchardWorker(
+          logger,
+          processRunner: (executable, arguments) async {
+            if (failTokenCommand) {
+              throw ProcessException(executable, arguments, 'not found');
+            }
+            return ProcessResult(1, 0, token, '');
+          },
+          processStarter: (executable, arguments, {required mode}) async {
+            throw ProcessException(executable, arguments, 'not found');
+          },
+        );
+
+        expect(result, 1);
+        expect(logger.stderrMessages, [
+          '${t.dev.start.stepOrchardWorkerFailed}\nnot found',
+        ]);
+        expect(logger.stderrMessages.join(), isNot(contains(token)));
+      },
+    );
+  }
+
+  for (final signal in [ProcessSignal.sigint, ProcessSignal.sigterm]) {
+    test('stops the worker on $signal and waits for shutdown', () async {
+      final listening = Completer<void>();
+      final interrupts = StreamController<ProcessSignal>(sync: true);
+      final terminations = StreamController<ProcessSignal>(
+        sync: true,
+        onListen: listening.complete,
+      );
+      addTearDown(interrupts.close);
+      addTearDown(terminations.close);
+      var completed = false;
+
+      final result =
+          startOrchardWorker(
+            logger,
+            processRunner: (_, _) async => ProcessResult(1, 0, token, ''),
+            processStarter: (_, _, {required mode}) async => worker,
+            interruptSignals: interrupts.stream,
+            terminateSignals: terminations.stream,
+          ).then((code) {
+            completed = true;
+            return code;
+          });
+      await listening.future;
+      (signal == ProcessSignal.sigint ? interrupts : terminations).add(signal);
+
+      expect(worker.signals, [ProcessSignal.sigint]);
+      expect(completed, isFalse);
+      worker.exited.complete(1);
+      expect(await result, 128 + signal.signalNumber);
+      expect(logger.stderrMessages, isEmpty);
+      expect(interrupts.hasListener, isFalse);
+      expect(terminations.hasListener, isFalse);
+    });
+  }
+}


### PR DESCRIPTION
`genuineci dev start` previously finished after starting Compose and configuring the Orchard context, leaving the Mac Orchard worker to be started separately. It now runs that worker in the foreground with terminal output, forwards shutdown requests, and waits for the worker to exit. Ctrl+C exits with 130; SIGTERM requests an Orchard shutdown and exits with 143. Docker containers keep running.

Add focused tests for startup order, setup failures, bootstrap-token failures, worker exit codes, and waiting for shutdown. Update English and Japanese help and startup messages.

Validation:
- `dart format --output=none --set-exit-if-changed apps/genuineci_cli`
- `flutter analyze --no-pub apps/genuineci_cli`
- `flutter test --coverage --no-pub --reporter=expanded`: 106 tests passed; the new worker launcher and `DevStartCommand` both have 100% local line coverage.
- Compiled CLI: verified help, stdout/stderr forwarding, and waiting for worker shutdown on SIGTERM using isolated executable fixtures.
- Real Mac: `genuineci dev start` registered the worker with the local Controller; Ctrl+C exited with 130 and left no host Orchard process. Existing `.env`, Orchard context, and build-job counts were unchanged; services started for verification were stopped afterward.

Starting the worker also reconciles existing Orchard VM definitions. The local Controller contained an older test definition, which started a Tart VM during verification; the worker removed that clone on shutdown. No new build job or workflow was submitted.

GitHub Actions: all five Dart app/package checks passed. Codecov reports **100.00% patch coverage** for `a0860e2a`.
