### PR TITLE
feat: create GitHub checks when build runs start

### DIFF
--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -83,6 +83,61 @@ class GitHubService {
     return tokenData['token'] as String;
   }
 
+  static Future<String> createGitHubCheckRun({
+    required String owner,
+    required String repo,
+    required String installationIdStr,
+    required String name,
+    required String headSha,
+    required String externalId,
+    Map<String, String>? environment,
+    http.Client? client,
+  }) async {
+    final env = environment ?? Platform.environment;
+    final githubApiBaseUrl = env['GITHUB_API_BASE_URL'];
+    if (githubApiBaseUrl == null || githubApiBaseUrl.isEmpty) {
+      throw StateError(
+        'GITHUB_API_BASE_URL environment variable is not configured',
+      );
+    }
+
+    final token = await getInstallationToken(
+      installationIdStr: installationIdStr,
+      environment: environment,
+      client: client,
+    );
+    final url = Uri.parse('$githubApiBaseUrl/repos/$owner/$repo/check-runs');
+    final headers = {
+      'Authorization': 'Bearer $token',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'OpenCI-Server',
+      'Content-Type': 'application/json',
+    };
+    final body = jsonEncode({
+      'name': name,
+      'head_sha': headSha,
+      'external_id': externalId,
+      'status': 'in_progress',
+      'started_at': DateTime.now().toUtc().toIso8601String(),
+    });
+    final response = client != null
+        ? await client.post(url, headers: headers, body: body)
+        : await http.post(url, headers: headers, body: body);
+    if (response.statusCode != HttpStatus.created) {
+      throw HttpException(
+        'Failed to create GitHub check run: '
+        '${response.statusCode} ${response.body}',
+      );
+    }
+
+    final data = jsonDecode(response.body);
+    if (data case {'id': final int id} when id > 0) {
+      return id.toString();
+    }
+    throw const FormatException('GitHub check run response has no valid id');
+  }
+
   static Future<void> updateGitHubCheckRun({
     required String owner,
     required String repo,

--- a/apps/openci_server/routes/builds/[id]/runs/index.dart
+++ b/apps/openci_server/routes/builds/[id]/runs/index.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
+import 'package:drift/drift.dart';
+import 'package:http/http.dart' as http;
 import 'package:openci_server/database.dart';
 import 'package:openci_server/github/github_service.dart';
 import 'package:openci_server/request/error_handler.dart';
@@ -121,18 +123,59 @@ Future<Response> _post(RequestContext context, String id) async {
     }
 
     final driftJob = context.read<DriftBuildJob>();
-    if (driftJob.checkRunId != null && driftJob.installationId != null) {
+    final installationId = driftJob.installationId;
+    if (installationId != null &&
+        installationId.isNotEmpty &&
+        installationId != '12345678') {
       try {
-        await GitHubService.updateGitHubCheckRun(
-          owner: driftJob.owner,
-          repo: driftJob.repo,
-          checkRunIdStr: driftJob.checkRunId!,
-          installationIdStr: driftJob.installationId!,
-          runStatus: 'in_progress',
-        );
+        Map<String, String>? environment;
+        http.Client? client;
+        try {
+          environment = context.read<Map<String, String>>();
+        } catch (_) {
+          // GitHubService falls back to the process environment.
+        }
+        try {
+          client = context.read<http.Client>();
+        } catch (_) {
+          // GitHubService uses its default HTTP client.
+        }
+
+        final checkRunId = driftJob.checkRunId;
+        if (checkRunId == null || checkRunId.isEmpty) {
+          final commitSha = driftJob.commitSha;
+          if (commitSha == null || commitSha.isEmpty) {
+            throw StateError('commitSha is required to create a GitHub check');
+          }
+          final createdCheckRunId = await GitHubService.createGitHubCheckRun(
+            owner: driftJob.owner,
+            repo: driftJob.repo,
+            installationIdStr: installationId,
+            name: driftJob.workflowName,
+            headSha: commitSha,
+            externalId: driftJob.id,
+            environment: environment,
+            client: client,
+          );
+          await (db.update(
+            db.buildJobs,
+          )..where((job) => job.id.equals(id))).write(
+            BuildJobsCompanion(checkRunId: Value(createdCheckRunId)),
+          );
+        } else {
+          await GitHubService.updateGitHubCheckRun(
+            owner: driftJob.owner,
+            repo: driftJob.repo,
+            checkRunIdStr: checkRunId,
+            installationIdStr: installationId,
+            runStatus: 'in_progress',
+            environment: environment,
+            client: client,
+          );
+        }
       } catch (e) {
         stderr.writeln(
-          'Failed to update check run to in_progress for job ${driftJob.id}: $e',
+          'Failed to start GitHub check run for job ${driftJob.id}: $e',
         );
       }
     }

--- a/apps/openci_server/test/github/github_service_test.dart
+++ b/apps/openci_server/test/github/github_service_test.dart
@@ -614,6 +614,163 @@ void main() {
       );
     });
 
+    group('createGitHubCheckRun', () {
+      Future<String> createCheck({
+        http.Client? client,
+        Map<String, String>? environment,
+      }) => GitHubService.createGitHubCheckRun(
+        owner: 'org',
+        repo: 'mobile',
+        installationIdStr: '98765',
+        name: 'Flutter CI',
+        headSha: 'abc123',
+        externalId: 'job-123',
+        environment: environment ?? testEnv,
+        client: client,
+      );
+
+      test('creates an in-progress check and returns its ID', () async {
+        testEnv['GITHUB_API_BASE_URL'] = 'https://github.example.test/api/v3';
+        final requests = <http.Request>[];
+        final client = apiClient((request) {
+          requests.add(request);
+          return http.Response('{"id": 99999}', HttpStatus.created);
+        });
+
+        expect(await createCheck(client: client), '99999');
+        final request = requests.single;
+        expect(request.method, 'POST');
+        expect(
+          request.url.toString(),
+          'https://github.example.test/api/v3/repos/org/mobile/check-runs',
+        );
+        expect(request.headers['authorization'], 'Bearer ghs_test_token');
+        expect(request.headers['content-type'], 'application/json');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        final startedAt = DateTime.parse(body.remove('started_at') as String);
+        expect(startedAt.isUtc, isTrue);
+        expect(body, {
+          'name': 'Flutter CI',
+          'head_sha': 'abc123',
+          'external_id': 'job-123',
+          'status': 'in_progress',
+        });
+      });
+
+      test('uses the default HTTP client when none is supplied', () async {
+        final client = apiClient(
+          (_) => http.Response('{"id": 99999}', HttpStatus.created),
+        );
+
+        expect(
+          await http.runWithClient(() => createCheck(), () => client),
+          '99999',
+        );
+      });
+
+      test(
+        'reports missing process configuration when no environment is supplied',
+        () async {
+          final client = MockClient((_) async => fail('No request expected'));
+          addTearDown(client.close);
+
+          await expectLater(
+            GitHubService.createGitHubCheckRun(
+              owner: 'org',
+              repo: 'mobile',
+              installationIdStr: '98765',
+              name: 'Flutter CI',
+              headSha: 'abc123',
+              externalId: 'job-123',
+              client: client,
+            ),
+            throwsA(
+              isA<StateError>().having(
+                (error) => error.message,
+                'message',
+                'GITHUB_API_BASE_URL environment variable is not configured',
+              ),
+            ),
+          );
+        },
+        skip: (Platform.environment['GITHUB_API_BASE_URL'] ?? '').isNotEmpty
+            ? 'Requires an unconfigured process environment.'
+            : false,
+      );
+
+      for (final status in [
+        HttpStatus.forbidden,
+        HttpStatus.unprocessableEntity,
+      ]) {
+        test('reports a Check creation failure with status $status', () async {
+          final client = apiClient((_) => http.Response('Rejected', status));
+
+          await expectLater(
+            createCheck(client: client),
+            throwsA(
+              isA<HttpException>().having(
+                (e) => e.message,
+                'message',
+                contains('$status Rejected'),
+              ),
+            ),
+          );
+        });
+      }
+
+      for (final body in [
+        'not-json',
+        '[]',
+        '{}',
+        '{"id":"99999"}',
+        '{"id":0}',
+      ]) {
+        test('rejects an invalid Check response: $body', () async {
+          final client = apiClient(
+            (_) => http.Response(body, HttpStatus.created),
+          );
+
+          await expectLater(createCheck(client: client), throwsFormatException);
+        });
+      }
+
+      for (final baseUrl in [null, '']) {
+        test('rejects missing API configuration: $baseUrl', () async {
+          final env = Map<String, String>.from(testEnv)
+            ..remove('GITHUB_API_BASE_URL');
+          if (baseUrl != null) env['GITHUB_API_BASE_URL'] = baseUrl;
+          final client = MockClient((_) async => fail('No request expected'));
+          addTearDown(client.close);
+
+          await expectLater(
+            createCheck(client: client, environment: env),
+            throwsStateError,
+          );
+        });
+      }
+
+      test(
+        'does not create a Check if installation authentication fails',
+        () async {
+          final requests = <http.Request>[];
+          final client = MockClient((request) async {
+            requests.add(request);
+            return http.Response('Forbidden', HttpStatus.forbidden);
+          });
+          addTearDown(client.close);
+
+          await expectLater(
+            createCheck(client: client),
+            throwsA(isA<HttpException>()),
+          );
+          expect(
+            requests.single.url.path,
+            '/app/installations/98765/access_tokens',
+          );
+        },
+      );
+    });
+
     group('updateGitHubCheckRun', () {
       test('successfully updates check run (queued/in_progress)', () async {
         var tokenRequested = false;

--- a/apps/openci_server/test/routes/builds/[id]/runs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs_test.dart
@@ -1,13 +1,18 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_frog/dart_frog.dart';
 import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:openci_server/database.dart';
 import 'package:openci_shared/openci_shared.dart';
 import 'package:test/test.dart';
 
 import '../../../../routes/builds/[id]/runs/index.dart' as route;
+import '../../../helpers/github_app_test_key.dart';
 
 DateTime _getNormalizedNow() {
   final now = DateTime.now().toUtc();
@@ -299,6 +304,213 @@ void main() {
         expect(body['error'], contains('Invalid payload structure'));
       },
     );
+  });
+
+  group('GitHub Check at build start', () {
+    late Directory tempDirectory;
+    late Map<String, String> environment;
+    late List<http.Request> requests;
+    late MockClient client;
+    var createStatus = HttpStatus.created;
+    var updateStatus = HttpStatus.ok;
+
+    setUp(() async {
+      tempDirectory = await Directory.systemTemp.createTemp('build_run_check_');
+      final keyFile = File('${tempDirectory.path}/key.pem');
+      await keyFile.writeAsString(testRsaPrivateKey);
+      environment = {
+        'GITHUB_APP_ID': '123456',
+        'GITHUB_PRIVATE_KEY_PATH': keyFile.path,
+        'GITHUB_API_BASE_URL': 'https://api.github.com',
+      };
+      requests = [];
+      createStatus = HttpStatus.created;
+      updateStatus = HttpStatus.ok;
+      client = MockClient((request) async {
+        requests.add(request);
+        if (request.url.path.endsWith('/access_tokens')) {
+          return http.Response('{"token":"test-token"}', HttpStatus.created);
+        }
+        if (request.method == 'POST' &&
+            request.url.path == '/repos/org/mobile/check-runs') {
+          return http.Response('{"id":99999}', createStatus);
+        }
+        if (request.method == 'PATCH' &&
+            request.url.path == '/repos/org/mobile/check-runs/99999') {
+          return http.Response('{}', updateStatus);
+        }
+        fail('Unexpected GitHub request: ${request.method} ${request.url}');
+      });
+      addTearDown(client.close);
+      addTearDown(() => tempDirectory.delete(recursive: true));
+
+      final now = _getNormalizedNow();
+      await db.buildJobDao.insertBuildJob(
+        DriftBuildJob(
+          id: 'job-check',
+          status: BuildJobStatus.IN_PROGRESS,
+          owner: 'org',
+          repo: 'mobile',
+          workflowName: 'Flutter CI',
+          workflowFileName: 'ci.dart',
+          installationId: '98765',
+          commitSha: 'abc123',
+          runCount: 2,
+          latestRunId: 'previous-run',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      );
+    });
+
+    Future<Response> startRun({
+      String runId = 'run-check',
+      bool provideEnvironment = true,
+      bool provideClient = true,
+    }) async {
+      final job = (await db.buildJobDao.getBuildJob('job-check'))!;
+      final context = TestRequestContext(
+        path: '/builds/job-check/runs',
+        method: HttpMethod.post,
+        body: jsonEncode({'id': runId}),
+      )..provide<AppDatabase>(db);
+      context.provide<DriftBuildJob>(job);
+      if (provideEnvironment) {
+        context.provide<Map<String, String>>(environment);
+      }
+      if (provideClient) context.provide<http.Client>(client);
+      return route.onRequest(context.context, job.id);
+    }
+
+    List<http.Request> checkRequests() => requests
+        .where((request) => request.url.path.contains('/check-runs'))
+        .toList();
+
+    for (final checkRunId in [null, '']) {
+      test('creates and saves a Check when the ID is $checkRunId', () async {
+        await db
+            .update(db.buildJobs)
+            .write(
+              BuildJobsCompanion(checkRunId: Value(checkRunId)),
+            );
+
+        final response = await startRun();
+
+        expect(response.statusCode, HttpStatus.ok);
+        final request = checkRequests().single;
+        expect(request.method, 'POST');
+        expect(jsonDecode(request.body), containsPair('head_sha', 'abc123'));
+        expect(jsonDecode(request.body), containsPair('name', 'Flutter CI'));
+        expect(
+          jsonDecode(request.body),
+          containsPair('external_id', 'job-check'),
+        );
+        final stored = (await db.buildJobDao.getBuildJob('job-check'))!;
+        expect(stored.checkRunId, '99999');
+        expect(stored.runCount, 3);
+        expect(stored.latestRunId, 'run-check');
+        expect(stored.status, BuildJobStatus.IN_PROGRESS);
+        expect(
+          (await db.buildRunDao.getBuildRun('job-check', 'run-check'))!.status,
+          'in_progress',
+        );
+      });
+    }
+
+    test('reuses the saved Check on a subsequent run', () async {
+      expect((await startRun()).statusCode, HttpStatus.ok);
+      expect((await startRun(runId: 'rerun')).statusCode, HttpStatus.ok);
+
+      final calls = checkRequests();
+      expect(calls.map((request) => request.method), ['POST', 'PATCH']);
+      expect(calls.last.url.path, '/repos/org/mobile/check-runs/99999');
+      expect(jsonDecode(calls.last.body), {'status': 'in_progress'});
+      final stored = (await db.buildJobDao.getBuildJob('job-check'))!;
+      expect(stored.checkRunId, '99999');
+      expect(stored.runCount, 4);
+      expect(stored.latestRunId, 'rerun');
+    });
+
+    test('does not create another Check for a duplicate run ID', () async {
+      expect((await startRun()).statusCode, HttpStatus.ok);
+      expect((await startRun()).statusCode, HttpStatus.conflict);
+      expect(checkRequests(), hasLength(1));
+    });
+
+    test('keeps the build run when Check creation fails', () async {
+      createStatus = HttpStatus.forbidden;
+
+      expect((await startRun()).statusCode, HttpStatus.ok);
+      expect(checkRequests().single.method, 'POST');
+      final stored = (await db.buildJobDao.getBuildJob('job-check'))!;
+      expect(stored.checkRunId, isNull);
+      expect(stored.runCount, 3);
+      expect(
+        await db.buildRunDao.getBuildRun('job-check', 'run-check'),
+        isNotNull,
+      );
+    });
+
+    test('preserves an existing Check if its update fails', () async {
+      await db
+          .update(db.buildJobs)
+          .write(
+            const BuildJobsCompanion(
+              checkRunId: Value('99999'),
+              commitSha: Value(null),
+            ),
+          );
+      updateStatus = HttpStatus.internalServerError;
+
+      expect((await startRun()).statusCode, HttpStatus.ok);
+      expect(checkRequests().single.method, 'PATCH');
+      expect(
+        (await db.buildJobDao.getBuildJob('job-check'))!.checkRunId,
+        '99999',
+      );
+    });
+
+    for (final installationId in [null, '', '12345678']) {
+      test(
+        'skips GitHub for an absent or dummy installation: $installationId',
+        () async {
+          await db
+              .update(db.buildJobs)
+              .write(
+                BuildJobsCompanion(installationId: Value(installationId)),
+              );
+
+          expect((await startRun()).statusCode, HttpStatus.ok);
+          expect(requests, isEmpty);
+          expect(
+            (await db.buildJobDao.getBuildJob('job-check'))!.checkRunId,
+            isNull,
+          );
+        },
+      );
+    }
+
+    for (final commitSha in [null, '']) {
+      test('skips Check creation when commit SHA is $commitSha', () async {
+        await db
+            .update(db.buildJobs)
+            .write(
+              BuildJobsCompanion(commitSha: Value(commitSha)),
+            );
+
+        final response = await startRun(
+          provideEnvironment: false,
+          provideClient: false,
+        );
+
+        expect(response.statusCode, HttpStatus.ok);
+        expect(requests, isEmpty);
+        expect(
+          (await db.buildJobDao.getBuildJob('job-check'))!.checkRunId,
+          isNull,
+        );
+      });
+    }
   });
 
   group('GET /builds/<id>/runs', () {


### PR DESCRIPTION
Build jobs created without a GitHub Check ID could not publish their final result to GitHub. When `POST /builds/:id/runs` starts a build, create an `in_progress` Check for the job's commit and save its ID. Subsequent runs update the saved Check. The database write changes only `checkRunId`, preserving the run count and latest run ID updated earlier in the request.

Keep the existing best-effort behavior: GitHub failures are logged and the build run remains available. Jobs with no installation ID, the legacy dummy installation ID, or no commit SHA skip Check creation. No schema or dependency changes.

Validation:
- Format and static analysis passed for `apps/openci_server`.
- Full server suite: 520 tests passed, including PostgreSQL integration tests. After adding the default-environment regression case, all 38 GitHub service tests passed.
- Local coverage: all modified executable lines are covered (including `routes/`).
- Tests cover creation and persistence, saved-ID reuse, duplicate run IDs, creation/update failures, missing metadata, malformed API responses, and the default HTTP client/configuration paths.
- GitHub API calls use test HTTP clients; no live GitHub Check was created. The disposable PostgreSQL test container was removed after validation.

GitHub Actions: all five Dart app/package checks passed. The final server suite passed 521 tests, including the new default-environment case. Codecov confirms **100.00% patch coverage** for `8610a24b`.
