### PR TITLE
feat: configure real build jobs for dev start seed

### DIFF
--- a/apps/genuineci_cli/README.md
+++ b/apps/genuineci_cli/README.md
@@ -1,1 +1,24 @@
-A sample command-line application providing basic argument parsing with an entrypoint in `bin/`.
+# GenuineCI CLI
+
+Start the local Docker services and foreground Orchard worker from the OpenCI checkout:
+
+```sh
+genuineci dev start
+```
+
+To submit one real build job, provide all seed options:
+
+```sh
+genuineci dev start --seed \
+  --seed-repository=OWNER/REPO \
+  --seed-sha=FULL_40_CHARACTER_COMMIT_SHA \
+  --seed-workflow=worker_smoke.dart \
+  --seed-installation-id=GITHUB_APP_INSTALLATION_ID \
+  --seed-branch=BRANCH
+```
+
+The workflow must exist under `genuine_ci/` at that pushed commit. The configured
+GitHub App must have access to the repository. Existing Compose credentials and
+local Tart/Orchard setup are required. Each invocation with `--seed` creates a new
+job in the local test team; it does not send a webhook or exercise the planner.
+Ctrl+C stops the foreground worker; Docker services remain running.

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -17,7 +17,8 @@ typedef TartBaseImageChecker = Future<bool> Function(Logger logger);
 typedef DockerComposeStarter =
     Future<bool> Function(Logger logger, Directory projectRoot);
 typedef OrchardContextSetup = Future<bool> Function(Logger logger);
-typedef LocalDataSeeder = Future<bool> Function(Logger logger);
+typedef LocalDataSeeder =
+    Future<bool> Function(Logger logger, Map<String, String> job);
 typedef OrchardWorkerStarter = Future<int> Function(Logger logger);
 
 class DevStartCommand extends Command<int> {
@@ -55,10 +56,63 @@ class DevStartCommand extends Command<int> {
        _localDataSeeder = localDataSeeder,
        _orchardWorkerStarter = orchardWorkerStarter {
     argParser.addFlag('seed', negatable: false, help: t.dev.start.flags.seed);
+    for (final entry in const {
+      'seed-repository': 'GitHub repository: owner/repo',
+      'seed-sha': 'Full commit SHA to check out',
+      'seed-workflow':
+          'Dart filename inside genuine_ci/ (e.g. worker_smoke.dart)',
+      'seed-installation-id': 'GitHub App installation ID',
+      'seed-branch': 'Branch containing the commit',
+    }.entries) {
+      argParser.addOption(
+        entry.key,
+        help: '${entry.value} (required with --seed)',
+      );
+    }
   }
 
   @override
   Future<int> run() async {
+    final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
+    final job = <String, String>{};
+    for (final option in argParser.options.keys.where(
+      (name) => name.startsWith('seed-'),
+    )) {
+      final value = argResults?[option] as String?;
+      if (shouldSeedLocalData && (value == null || value.trim().isEmpty)) {
+        usageException('--$option is required with --seed.');
+      }
+      if (!shouldSeedLocalData && value != null) {
+        usageException('--$option requires --seed.');
+      }
+      if (value != null) job[option] = value.trim();
+    }
+    if (shouldSeedLocalData) {
+      if (!RegExp(
+        r'^[A-Za-z0-9][A-Za-z0-9-]*/[A-Za-z0-9_.-]+$',
+      ).hasMatch(job['seed-repository']!)) {
+        usageException('--seed-repository must be owner/repo.');
+      }
+      if (!RegExp(r'^[a-fA-F0-9]{40}$').hasMatch(job['seed-sha']!)) {
+        usageException('--seed-sha must be a full 40-character commit SHA.');
+      }
+      if (!RegExp(
+        r'^[A-Za-z0-9_-][A-Za-z0-9_.-]*\.dart$',
+      ).hasMatch(job['seed-workflow']!)) {
+        usageException(
+          '--seed-workflow must be a Dart filename inside genuine_ci/.',
+        );
+      }
+      final installationId = int.tryParse(job['seed-installation-id']!);
+      if (!RegExp(r'^[1-9][0-9]*$').hasMatch(job['seed-installation-id']!) ||
+          installationId == null ||
+          installationId <= 0 ||
+          installationId == 12345678) {
+        usageException(
+          '--seed-installation-id must be a real positive installation ID.',
+        );
+      }
+    }
     _logger.stdout(t.dev.start.starting);
 
     final projectRoot = _projectRootFinder();
@@ -85,9 +139,16 @@ class DevStartCommand extends Command<int> {
       return 1;
     }
 
-    final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
     if (shouldSeedLocalData) {
-      final didSeedLocalData = await _localDataSeeder(_logger);
+      final didSeedLocalData = await _localDataSeeder(_logger, {
+        'owner': job['seed-repository']!.split('/').first,
+        'repo': job['seed-repository']!.split('/').last,
+        'commitSha': job['seed-sha']!,
+        'workflowFileName': job['seed-workflow']!,
+        'workflowName': job['seed-workflow']!,
+        'installationId': job['seed-installation-id']!,
+        'branch': job['seed-branch']!,
+      });
       if (!didSeedLocalData) {
         return 1;
       }

--- a/apps/genuineci_cli/lib/src/commands/dev/seed_local_data.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/seed_local_data.dart
@@ -2,18 +2,17 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_util/cli_logging.dart';
-import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
 import '../../i18n/i18n.dart';
 
 const _defaultServerUrl = 'http://localhost:8080';
-const _defaultWebhookSecret = 'your-github-webhook-secret-here';
 const _defaultTimeout = Duration(seconds: 10);
 
 Future<bool> seedLocalData(
-  Logger logger, {
+  Logger logger,
+  Map<String, String> job, {
   @visibleForTesting http.Client? client,
   @visibleForTesting Map<String, String>? environment,
   @visibleForTesting Duration timeout = _defaultTimeout,
@@ -23,54 +22,17 @@ Future<bool> seedLocalData(
   final httpClient = client ?? http.Client();
   final env = environment ?? Platform.environment;
   final serverUrl = env['OPENCI_SERVER_URL'] ?? _defaultServerUrl;
-  final webhookSecret = env['GITHUB_WEBHOOK_SECRET'] ?? _defaultWebhookSecret;
 
   try {
     final seedResponse = await httpClient
         .post(
           Uri.parse('$serverUrl/internal/seed'),
           headers: {'Content-Type': 'application/json'},
-          body: jsonEncode({}),
+          body: jsonEncode(job),
         )
         .timeout(timeout);
     if (!_isSuccessful(seedResponse)) {
       _logFailedResponse(logger, seedResponse);
-      return false;
-    }
-
-    final webhookPayload = {
-      'ref': 'refs/heads/main',
-      'repository': {
-        'name': 'openci',
-        'owner': {'login': 'openci-org'},
-      },
-      'installation': {'id': 12345678},
-      'head_commit': {
-        'id': 'main',
-        'message': 'feat: 🎉 Hello World from OpenCI Local Orchard via API!',
-      },
-    };
-    final rawBody = jsonEncode(webhookPayload);
-    final digest = Hmac(
-      sha256,
-      utf8.encode(webhookSecret),
-    ).convert(utf8.encode(rawBody));
-
-    final webhookResponse = await httpClient
-        .post(
-          Uri.parse('$serverUrl/webhook'),
-          headers: {
-            'Content-Type': 'application/json',
-            'X-GitHub-Event': 'push',
-            'X-GitHub-Delivery':
-                'delivery-${DateTime.now().millisecondsSinceEpoch}',
-            'X-Hub-Signature-256': 'sha256=$digest',
-          },
-          body: rawBody,
-        )
-        .timeout(timeout);
-    if (!_isSuccessful(webhookResponse)) {
-      _logFailedResponse(logger, webhookResponse);
       return false;
     }
   } catch (error) {

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -20,6 +20,15 @@ class _RecordingLogger implements Logger {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+const seedArgs = [
+  '--seed',
+  '--seed-repository=example/project',
+  '--seed-sha=0123456789012345678901234567890123456789',
+  '--seed-workflow=smoke.dart',
+  '--seed-installation-id=42',
+  '--seed-branch=develop',
+];
+
 void main() {
   late Directory originalDirectory;
   late Directory tempDirectory;
@@ -51,7 +60,16 @@ void main() {
           tartBaseImageChecker: (_) async => true,
           dockerComposeStarter: (_, _) async => true,
           orchardContextSetup: (_) async => true,
-          localDataSeeder: (_) async {
+          localDataSeeder: (_, job) async {
+            expect(job, {
+              'owner': 'example',
+              'repo': 'project',
+              'commitSha': '0123456789012345678901234567890123456789',
+              'workflowFileName': 'smoke.dart',
+              'workflowName': 'smoke.dart',
+              'installationId': '42',
+              'branch': 'develop',
+            });
             onSeed();
             return seedSucceeds;
           },
@@ -59,7 +77,48 @@ void main() {
         ),
       );
 
-    return runner.run(['start', if (shouldSeed) '--seed']);
+    return runner.run(['start', if (shouldSeed) ...seedArgs]);
+  }
+
+  for (final args in [
+    ['--seed'],
+    for (var i = 1; i < seedArgs.length; i++)
+      [...seedArgs.take(i), ...seedArgs.skip(i + 1)],
+    ['--seed-repository=example/project'],
+    for (final invalid in [
+      '--seed-repository=invalid',
+      '--seed-repository=../project',
+      '--seed-sha=main',
+      '--seed-workflow=../smoke.dart',
+      '--seed-workflow=ci.yml',
+      '--seed-installation-id=0',
+      '--seed-installation-id=abc',
+      '--seed-installation-id=0x2a',
+      '--seed-installation-id=-1',
+      '--seed-installation-id=999999999999999999999999',
+      '--seed-installation-id=12345678',
+      '--seed-branch= ',
+    ])
+      [
+        ...seedArgs.where(
+          (arg) => arg.split('=').first != invalid.split('=').first,
+        ),
+        invalid,
+      ],
+  ]) {
+    test('rejects invalid seed arguments before setup: $args', () async {
+      final runner = CommandRunner<int>('genuineci', 'CLI')
+        ..addCommand(
+          DevStartCommand(
+            logger: _RecordingLogger(),
+            projectRootFinder: () => fail('Must validate before setup'),
+          ),
+        );
+      await expectLater(
+        runner.run(['start', ...args]),
+        throwsA(isA<UsageException>()),
+      );
+    });
   }
 
   test('reports projectRootNotFound before checking Tart', () async {
@@ -137,7 +196,7 @@ void main() {
             tartBaseImageChecker: (_) async => recordStep('tart'),
             dockerComposeStarter: (_, _) async => recordStep('compose'),
             orchardContextSetup: (_) async => recordStep('context'),
-            localDataSeeder: (_) async => recordStep('seed'),
+            localDataSeeder: (_, _) async => recordStep('seed'),
             orchardWorkerStarter: (workerLogger) async {
               expect(workerLogger, same(logger));
               calls.add('worker');
@@ -146,7 +205,7 @@ void main() {
           ),
         );
 
-      expect(await runner.run(['start', if (shouldSeed) '--seed']), 17);
+      expect(await runner.run(['start', if (shouldSeed) ...seedArgs]), 17);
       expect(calls, [
         'tart',
         'compose',

--- a/apps/genuineci_cli/test/src/commands/dev/seed_local_data_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/seed_local_data_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:cli_util/cli_logging.dart';
-import 'package:crypto/crypto.dart';
 import 'package:genuineci_cli/src/commands/dev/seed_local_data.dart';
 import 'package:genuineci_cli/src/i18n/i18n.dart';
 import 'package:http/http.dart' as http;
@@ -23,6 +22,15 @@ class _RecordingLogger implements Logger {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+const job = {
+  'owner': 'example',
+  'repo': 'project',
+  'commitSha': '0123456789012345678901234567890123456789',
+  'workflowFileName': 'smoke.dart',
+  'installationId': '42',
+  'branch': 'develop',
+};
+
 void main() {
   group('seedLocalData', () {
     late _RecordingLogger logger;
@@ -31,58 +39,25 @@ void main() {
       logger = _RecordingLogger();
     });
 
-    test('seeds a team and dispatches a signed push webhook', () async {
-      const serverUrl = 'http://localhost:9090';
-      const webhookSecret = 'test-secret';
+    test('submits exactly one configured job', () async {
       final requests = <http.Request>[];
-      final client = MockClient((request) async {
-        requests.add(request);
-        return http.Response('{}', 200);
-      });
-
       final result = await seedLocalData(
         logger,
-        client: client,
-        environment: {
-          'OPENCI_SERVER_URL': serverUrl,
-          'GITHUB_WEBHOOK_SECRET': webhookSecret,
-        },
+        job,
+        client: MockClient((request) async {
+          requests.add(request);
+          return http.Response('{}', 200);
+        }),
+        environment: {'OPENCI_SERVER_URL': 'http://localhost:9090'},
       );
-
       expect(result, isTrue);
-      expect(requests, hasLength(2));
-
-      final seedRequest = requests[0];
-      expect(seedRequest.method, equals('POST'));
-      expect(seedRequest.url, equals(Uri.parse('$serverUrl/internal/seed')));
-      expect(seedRequest.headers['content-type'], equals('application/json'));
-      expect(jsonDecode(seedRequest.body), equals({}));
-
-      final webhookRequest = requests[1];
-      expect(webhookRequest.method, equals('POST'));
-      expect(webhookRequest.url, equals(Uri.parse('$serverUrl/webhook')));
-      expect(webhookRequest.headers['x-github-event'], equals('push'));
-      expect(
-        webhookRequest.headers['x-github-delivery'],
-        matches(RegExp(r'^delivery-\d+$')),
-      );
-      final expectedDigest = Hmac(
-        sha256,
-        utf8.encode(webhookSecret),
-      ).convert(utf8.encode(webhookRequest.body));
-      expect(
-        webhookRequest.headers['x-hub-signature-256'],
-        equals('sha256=$expectedDigest'),
-      );
-      expect(
-        jsonDecode(webhookRequest.body),
-        containsPair('ref', 'refs/heads/main'),
-      );
+      final request = requests.single;
+      expect(request.method, 'POST');
+      expect(request.url.toString(), 'http://localhost:9090/internal/seed');
+      expect(request.headers['content-type'], 'application/json');
+      expect(jsonDecode(request.body), job);
       expect(logger.stderrMessages, isEmpty);
-      expect(logger.stdoutMessages, [
-        '\n${t.dev.start.stepSeed}',
-        t.dev.start.stepSeedCompleted,
-      ]);
+      expect(logger.stdoutMessages.last, t.dev.start.stepSeedCompleted);
     });
 
     test('returns false when the seed request fails', () async {
@@ -94,6 +69,7 @@ void main() {
 
       final result = await seedLocalData(
         logger,
+        job,
         client: client,
         environment: const {},
       );
@@ -109,28 +85,6 @@ void main() {
       expect(logger.stdoutMessages, ['\n${t.dev.start.stepSeed}']);
     });
 
-    test('returns false when the webhook request fails', () async {
-      final client = MockClient((request) async {
-        if (request.url.path == '/webhook') {
-          return http.Response('webhook failed', 500);
-        }
-        return http.Response('{}', 200);
-      });
-
-      final result = await seedLocalData(
-        logger,
-        client: client,
-        environment: const {},
-      );
-
-      expect(result, isFalse);
-      expect(
-        logger.stderrMessages.single,
-        contains(t.dev.start.stepSeedFailed),
-      );
-      expect(logger.stderrMessages.single, contains('Body: webhook failed'));
-    });
-
     test('returns false when an HTTP request throws', () async {
       final client = MockClient(
         (_) async => throw Exception('connection failed'),
@@ -138,6 +92,7 @@ void main() {
 
       final result = await seedLocalData(
         logger,
+        job,
         client: client,
         environment: const {},
       );
@@ -156,6 +111,7 @@ void main() {
 
       final result = await seedLocalData(
         logger,
+        job,
         client: client,
         environment: const {},
         timeout: const Duration(milliseconds: 50),
@@ -168,29 +124,6 @@ void main() {
       );
       expect(logger.stderrMessages.single, contains('TimeoutException'));
       expect(logger.stdoutMessages, ['\n${t.dev.start.stepSeed}']);
-    });
-
-    test('returns false when webhook request times out', () async {
-      final client = MockClient((request) {
-        if (request.url.path == '/internal/seed') {
-          return Future.value(http.Response('{}', 200));
-        }
-        return Completer<http.Response>().future;
-      });
-
-      final result = await seedLocalData(
-        logger,
-        client: client,
-        environment: const {},
-        timeout: const Duration(milliseconds: 50),
-      );
-
-      expect(result, isFalse);
-      expect(
-        logger.stderrMessages.single,
-        contains(t.dev.start.stepSeedFailed),
-      );
-      expect(logger.stderrMessages.single, contains('TimeoutException'));
     });
   });
 }


### PR DESCRIPTION
`genuineci dev start --seed` previously created a job with dummy defaults and also sent a synthetic webhook. It now requires a repository, full commit SHA, Dart workflow filename, GitHub App installation ID, and branch, then submits one job through the existing seed API.

Invalid or missing options fail before local services start. The README documents the invocation and local test-team behavior. This checks the worker path; webhook/planner verification remains separate.

Validation: formatter, Flutter analyzer, 123 CLI tests, and compiled CLI help/usage-error checks. Local coverage covers all new executable lines. Reviewed all five changed files. HTTP calls are mocked; no live VM build was submitted in this PR.
