### PR TITLE
refactor: reorganize worker startup sequence and enhance Docker Compo…

### DIFF
--- a/apps/genuineci_cli/README.md
+++ b/apps/genuineci_cli/README.md
@@ -4,6 +4,11 @@ Run `genuineci dev start` from the OpenCI checkout to start local services and t
 Mac Orchard worker. The existing Docker Compose credentials and `base-macos` VM
 must be configured first.
 
+The command starts Orchard Controller and the Mac worker first. When restarting,
+it stops the old build-job-worker and waits for its current job to finish while
+the server remains available for saving results and deleting the VM. It then
+rebuilds and starts the application containers.
+
 To also queue the default smoke-test build job:
 
 ```sh

--- a/apps/genuineci_cli/lib/i18n/en.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/en.i18n.json
@@ -34,7 +34,7 @@
       "stepTart": "Step 1: Checking Tart VM base image...",
       "stepTartNotFound": "Error: Tart VM image \"base-macos\" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
       "stepTartExists": "Tart VM (base-macos) exists.",
-      "stepDockerCompose": "Step 2: Starting Docker containers...",
+      "stepDockerCompose": "Step 5: Starting Docker containers...",
       "stepDockerComposeFailed": "Error: Failed to start Docker containers.",
       "stepDockerComposeStarted": "Docker containers started.",
       "stepOrchardWaiting": "Step 3: Waiting for Orchard Controller to initialize...",
@@ -44,10 +44,12 @@
       "stepOrchardContextRegistered": "Orchard CLI context authenticated.",
       "stepOrchardWorker": "Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.",
       "stepOrchardWorkerFailed": "Error: Orchard Worker could not start or exited with an error.",
-      "stepSeed": "Step 5: Seeding local test data...",
+      "stepSeed": "Step 6: Seeding local test data...",
       "stepSeedFailed": "Error: Failed to seed local test data.",
       "stepSeedCompleted": "Local test data seeded.",
-      "projectRootNotFound": "Error: OpenCI project root not found."
+      "projectRootNotFound": "Error: OpenCI project root not found.",
+      "stepOrchardController": "Step 2: Starting Orchard Controller...",
+      "stepBuildJobWorkerWaiting": "Waiting for the current build job to finish before restarting services..."
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/i18n/ja.i18n.json
+++ b/apps/genuineci_cli/lib/i18n/ja.i18n.json
@@ -34,7 +34,7 @@
       "stepTart": "Step 1: Tart VM ベースイメージを確認中...",
       "stepTartNotFound": "エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos",
       "stepTartExists": "Tart VM (base-macos) を確認しました。",
-      "stepDockerCompose": "Step 2: Docker コンテナを起動中...",
+      "stepDockerCompose": "Step 5: Docker コンテナを起動中...",
       "stepDockerComposeFailed": "エラー: Docker コンテナの起動に失敗しました。",
       "stepDockerComposeStarted": "Docker コンテナを起動しました。",
       "stepOrchardWaiting": "Step 3: Orchard Controller の起動を待機中...",
@@ -44,10 +44,12 @@
       "stepOrchardContextRegistered": "Orchard CLI コンテキストを認証しました。",
       "stepOrchardWorker": "Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。",
       "stepOrchardWorkerFailed": "エラー: Orchard Workerを起動できなかったか、異常終了しました。",
-      "stepSeed": "Step 5: ローカルテストデータを投入中...",
+      "stepSeed": "Step 6: ローカルテストデータを投入中...",
       "stepSeedFailed": "エラー: ローカルテストデータの投入に失敗しました。",
       "stepSeedCompleted": "ローカルテストデータを投入しました。",
-      "projectRootNotFound": "エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。"
+      "projectRootNotFound": "エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。",
+      "stepOrchardController": "Step 2: Orchard Controllerを起動中...",
+      "stepBuildJobWorkerWaiting": "サービスを再起動する前に、実行中のビルドジョブの終了を待っています..."
     }
   },
   "common": {

--- a/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/dev_start_command.dart
@@ -15,10 +15,14 @@ import 'start_orchard_worker.dart';
 typedef ProjectRootFinder = Directory? Function();
 typedef TartBaseImageChecker = Future<bool> Function(Logger logger);
 typedef DockerComposeStarter =
-    Future<bool> Function(Logger logger, Directory projectRoot);
+    Future<bool> Function(
+      Logger logger,
+      Directory projectRoot, {
+      DockerComposeStep step,
+    });
 typedef OrchardContextSetup = Future<bool> Function(Logger logger);
 typedef LocalDataSeeder = Future<bool> Function(Logger logger);
-typedef OrchardWorkerStarter = Future<int> Function(Logger logger);
+typedef OrchardWorkerStarter = Future<OrchardWorker?> Function(Logger logger);
 
 class DevStartCommand extends Command<int> {
   @override
@@ -72,11 +76,12 @@ class DevStartCommand extends Command<int> {
       return 1;
     }
 
-    final didStartDockerCompose = await _dockerComposeStarter(
+    final didStartController = await _dockerComposeStarter(
       _logger,
       projectRoot,
+      step: DockerComposeStep.startOrchardController,
     );
-    if (!didStartDockerCompose) {
+    if (!didStartController) {
       return 1;
     }
 
@@ -85,14 +90,34 @@ class DevStartCommand extends Command<int> {
       return 1;
     }
 
-    final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
-    if (shouldSeedLocalData) {
-      final didSeedLocalData = await _localDataSeeder(_logger);
-      if (!didSeedLocalData) {
-        return 1;
-      }
+    final worker = await _orchardWorkerStarter(_logger);
+    if (worker == null) {
+      return 1;
     }
 
-    return _orchardWorkerStarter(_logger);
+    try {
+      final shouldSeedLocalData = argResults?['seed'] as bool? ?? false;
+      for (final start in [
+        () => _dockerComposeStarter(
+          _logger,
+          projectRoot,
+          step: DockerComposeStep.stopBuildJobWorker,
+        ),
+        () => _dockerComposeStarter(_logger, projectRoot),
+        if (shouldSeedLocalData) () => _localDataSeeder(_logger),
+      ]) {
+        if (!worker.isRunning) {
+          final code = await worker.exitCode;
+          return code == 0 ? 1 : code;
+        }
+        if (!await start()) {
+          return 1;
+        }
+      }
+
+      return await worker.exitCode;
+    } finally {
+      await worker.stop();
+    }
   }
 }

--- a/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
@@ -13,32 +13,51 @@ typedef DockerComposeProcessRunner =
       required Map<String, String> environment,
     });
 
-const _dockerComposeArguments = [
-  'compose',
-  'up',
-  '-d',
-  '--build',
-  'server',
-  'build-job-planner',
-  'build-job-worker',
-  'loki',
-];
+enum DockerComposeStep {
+  startOrchardController,
+  stopBuildJobWorker,
+  startServices,
+}
 
 Future<bool> startDockerCompose(
   Logger logger,
   Directory projectRoot, {
+  DockerComposeStep step = DockerComposeStep.startServices,
   @visibleForTesting
   DockerComposeProcessRunner processRunner = _runDockerComposeProcess,
   @visibleForTesting Map<String, String>? environment,
 }) async {
-  logger.stdout('\n${t.dev.start.stepDockerCompose}');
+  final (arguments, message) = switch (step) {
+    DockerComposeStep.startOrchardController => (
+      ['compose', 'up', '-d', '--no-recreate', 'orchard-controller'],
+      t.dev.start.stepOrchardController,
+    ),
+    DockerComposeStep.stopBuildJobWorker => (
+      ['compose', 'stop', 'build-job-worker'],
+      t.dev.start.stepBuildJobWorkerWaiting,
+    ),
+    DockerComposeStep.startServices => (
+      [
+        'compose',
+        'up',
+        '-d',
+        '--build',
+        'server',
+        'build-job-planner',
+        'build-job-worker',
+        'loki',
+      ],
+      t.dev.start.stepDockerCompose,
+    ),
+  };
+  logger.stdout('\n$message');
 
   final composeEnvironment = environment ?? Platform.environment;
 
   try {
     final exitCode = await processRunner(
       'docker',
-      _dockerComposeArguments,
+      arguments,
       workingDirectory: projectRoot.path,
       environment: composeEnvironment,
     );
@@ -51,7 +70,9 @@ Future<bool> startDockerCompose(
     return false;
   }
 
-  logger.stdout(t.dev.start.stepDockerComposeStarted);
+  if (step == DockerComposeStep.startServices) {
+    logger.stdout(t.dev.start.stepDockerComposeStarted);
+  }
   return true;
 }
 

--- a/apps/genuineci_cli/lib/src/commands/dev/start_orchard_worker.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_orchard_worker.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:cli_util/cli_logging.dart';
@@ -13,7 +14,8 @@ typedef OrchardWorkerProcessStarter =
       required ProcessStartMode mode,
     });
 
-Future<int> startOrchardWorker(
+/// Starts the Mac worker. The caller must [OrchardWorker.stop] it when done.
+Future<OrchardWorker?> startOrchardWorker(
   Logger logger, {
   @visibleForTesting OrchardProcessRunner processRunner = Process.run,
   @visibleForTesting OrchardWorkerProcessStarter processStarter = Process.start,
@@ -29,7 +31,7 @@ Future<int> startOrchardWorker(
     final token = tokenResult.stdout.toString().trim();
     if (tokenResult.exitCode != 0 || token.isEmpty) {
       logger.stderr(t.dev.start.stepOrchardWorkerFailed);
-      return 1;
+      return null;
     }
 
     logger.stdout('\n${t.dev.start.stepOrchardWorker}');
@@ -42,32 +44,73 @@ Future<int> startOrchardWorker(
       '--no-pki',
     ], mode: ProcessStartMode.inheritStdio);
 
-    ProcessSignal? stopSignal;
-    void stop(ProcessSignal signal) {
-      stopSignal ??= signal;
-      // Orchard handles SIGINT by shutting down its worker.
-      process.kill(ProcessSignal.sigint);
-    }
-
-    final interruptSubscription =
-        (interruptSignals ?? ProcessSignal.sigint.watch()).listen(stop);
-    final terminateSubscription =
-        (terminateSignals ?? ProcessSignal.sigterm.watch()).listen(stop);
-    try {
-      final exitCode = await process.exitCode;
-      if (stopSignal != null) {
-        return 128 + stopSignal!.signalNumber;
-      }
-      if (exitCode != 0) {
-        logger.stderr(t.dev.start.stepOrchardWorkerFailed);
-      }
-      return exitCode < 0 ? 128 - exitCode : exitCode;
-    } finally {
-      await interruptSubscription.cancel();
-      await terminateSubscription.cancel();
-    }
+    return OrchardWorker._(
+      process,
+      logger,
+      interruptSignals ?? ProcessSignal.sigint.watch(),
+      terminateSignals ?? ProcessSignal.sigterm.watch(),
+    );
   } on ProcessException catch (error) {
     logger.stderr('${t.dev.start.stepOrchardWorkerFailed}\n${error.message}');
-    return 1;
+    return null;
+  }
+}
+
+class OrchardWorker {
+  final Process _process;
+  var _exited = false;
+  var _stopRequested = false;
+  ProcessSignal? _stopSignal;
+  late final Future<int> exitCode;
+
+  OrchardWorker._(
+    this._process,
+    Logger logger,
+    Stream<ProcessSignal> interruptSignals,
+    Stream<ProcessSignal> terminateSignals,
+  ) {
+    final subscriptions = [
+      interruptSignals.listen(_handleSignal),
+      terminateSignals.listen(_handleSignal),
+    ];
+    exitCode = _waitForExit(logger, subscriptions);
+  }
+
+  bool get isRunning => !_exited && !_stopRequested;
+
+  Future<void> stop() async {
+    if (isRunning) {
+      _stopRequested = true;
+      // Orchard handles SIGINT by shutting down its worker.
+      _process.kill(ProcessSignal.sigint);
+    }
+    await exitCode;
+  }
+
+  void _handleSignal(ProcessSignal signal) {
+    _stopSignal ??= signal;
+    _stopRequested = true;
+    _process.kill(ProcessSignal.sigint);
+  }
+
+  Future<int> _waitForExit(
+    Logger logger,
+    List<StreamSubscription<ProcessSignal>> subscriptions,
+  ) async {
+    try {
+      final code = await _process.exitCode;
+      if (_stopSignal != null) {
+        return 128 + _stopSignal!.signalNumber;
+      }
+      if (code != 0 && !_stopRequested) {
+        logger.stderr(t.dev.start.stepOrchardWorkerFailed);
+      }
+      return code < 0 ? 128 - code : code;
+    } finally {
+      _exited = true;
+      for (final subscription in subscriptions) {
+        await subscription.cancel();
+      }
+    }
   }
 }

--- a/apps/genuineci_cli/lib/src/gen/strings.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 2
-/// Strings: 72 (36 per locale)
+/// Strings: 76 (38 per locale)
 ///
-/// Built on 2026-09-09 at 01:37 UTC
+/// Built on 2026-09-09 at 06:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_en.g.dart
@@ -183,8 +183,8 @@ class Translations$dev$start$en {
 	/// en: 'Tart VM (base-macos) exists.'
 	String get stepTartExists => 'Tart VM (base-macos) exists.';
 
-	/// en: 'Step 2: Starting Docker containers...'
-	String get stepDockerCompose => 'Step 2: Starting Docker containers...';
+	/// en: 'Step 5: Starting Docker containers...'
+	String get stepDockerCompose => 'Step 5: Starting Docker containers...';
 
 	/// en: 'Error: Failed to start Docker containers.'
 	String get stepDockerComposeFailed => 'Error: Failed to start Docker containers.';
@@ -213,8 +213,8 @@ class Translations$dev$start$en {
 	/// en: 'Error: Orchard Worker could not start or exited with an error.'
 	String get stepOrchardWorkerFailed => 'Error: Orchard Worker could not start or exited with an error.';
 
-	/// en: 'Step 5: Seeding local test data...'
-	String get stepSeed => 'Step 5: Seeding local test data...';
+	/// en: 'Step 6: Seeding local test data...'
+	String get stepSeed => 'Step 6: Seeding local test data...';
 
 	/// en: 'Error: Failed to seed local test data.'
 	String get stepSeedFailed => 'Error: Failed to seed local test data.';
@@ -224,6 +224,12 @@ class Translations$dev$start$en {
 
 	/// en: 'Error: OpenCI project root not found.'
 	String get projectRootNotFound => 'Error: OpenCI project root not found.';
+
+	/// en: 'Step 2: Starting Orchard Controller...'
+	String get stepOrchardController => 'Step 2: Starting Orchard Controller...';
+
+	/// en: 'Waiting for the current build job to finish before restarting services...'
+	String get stepBuildJobWorkerWaiting => 'Waiting for the current build job to finish before restarting services...';
 }
 
 // Path: dev.start.flags
@@ -267,7 +273,7 @@ extension on Translations {
 			'dev.start.stepTart' => 'Step 1: Checking Tart VM base image...',
 			'dev.start.stepTartNotFound' => 'Error: Tart VM image "base-macos" not found.\nPlease run the following commands to setup the base image:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) exists.',
-			'dev.start.stepDockerCompose' => 'Step 2: Starting Docker containers...',
+			'dev.start.stepDockerCompose' => 'Step 5: Starting Docker containers...',
 			'dev.start.stepDockerComposeFailed' => 'Error: Failed to start Docker containers.',
 			'dev.start.stepDockerComposeStarted' => 'Docker containers started.',
 			'dev.start.stepOrchardWaiting' => 'Step 3: Waiting for Orchard Controller to initialize...',
@@ -277,10 +283,12 @@ extension on Translations {
 			'dev.start.stepOrchardContextRegistered' => 'Orchard CLI context authenticated.',
 			'dev.start.stepOrchardWorker' => 'Starting Orchard Worker on this Mac. Press Ctrl+C to stop it. Docker containers will keep running.',
 			'dev.start.stepOrchardWorkerFailed' => 'Error: Orchard Worker could not start or exited with an error.',
-			'dev.start.stepSeed' => 'Step 5: Seeding local test data...',
+			'dev.start.stepSeed' => 'Step 6: Seeding local test data...',
 			'dev.start.stepSeedFailed' => 'Error: Failed to seed local test data.',
 			'dev.start.stepSeedCompleted' => 'Local test data seeded.',
 			'dev.start.projectRootNotFound' => 'Error: OpenCI project root not found.',
+			'dev.start.stepOrchardController' => 'Step 2: Starting Orchard Controller...',
+			'dev.start.stepBuildJobWorkerWaiting' => 'Waiting for the current build job to finish before restarting services...',
 			'common.error' => ({required Object error}) => 'Error: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
+++ b/apps/genuineci_cli/lib/src/gen/strings_ja.g.dart
@@ -140,7 +140,7 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepTart => 'Step 1: Tart VM ベースイメージを確認中...';
 	@override String get stepTartNotFound => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos';
 	@override String get stepTartExists => 'Tart VM (base-macos) を確認しました。';
-	@override String get stepDockerCompose => 'Step 2: Docker コンテナを起動中...';
+	@override String get stepDockerCompose => 'Step 5: Docker コンテナを起動中...';
 	@override String get stepDockerComposeFailed => 'エラー: Docker コンテナの起動に失敗しました。';
 	@override String get stepDockerComposeStarted => 'Docker コンテナを起動しました。';
 	@override String get stepOrchardWaiting => 'Step 3: Orchard Controller の起動を待機中...';
@@ -150,10 +150,12 @@ class _Translations$dev$start$ja extends Translations$dev$start$en {
 	@override String get stepOrchardContextRegistered => 'Orchard CLI コンテキストを認証しました。';
 	@override String get stepOrchardWorker => 'Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。';
 	@override String get stepOrchardWorkerFailed => 'エラー: Orchard Workerを起動できなかったか、異常終了しました。';
-	@override String get stepSeed => 'Step 5: ローカルテストデータを投入中...';
+	@override String get stepSeed => 'Step 6: ローカルテストデータを投入中...';
 	@override String get stepSeedFailed => 'エラー: ローカルテストデータの投入に失敗しました。';
 	@override String get stepSeedCompleted => 'ローカルテストデータを投入しました。';
 	@override String get projectRootNotFound => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。';
+	@override String get stepOrchardController => 'Step 2: Orchard Controllerを起動中...';
+	@override String get stepBuildJobWorkerWaiting => 'サービスを再起動する前に、実行中のビルドジョブの終了を待っています...';
 }
 
 // Path: dev.start.flags
@@ -195,7 +197,7 @@ extension on TranslationsJa {
 			'dev.start.stepTart' => 'Step 1: Tart VM ベースイメージを確認中...',
 			'dev.start.stepTartNotFound' => 'エラー: Tart VM イメージ「base-macos」が見つかりません。\n以下のコマンドを実行してイメージを準備してください:\n  tart pull ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5\n  tart clone ghcr.io/cirruslabs/macos-tahoe-vanilla:26.5 base-macos',
 			'dev.start.stepTartExists' => 'Tart VM (base-macos) を確認しました。',
-			'dev.start.stepDockerCompose' => 'Step 2: Docker コンテナを起動中...',
+			'dev.start.stepDockerCompose' => 'Step 5: Docker コンテナを起動中...',
 			'dev.start.stepDockerComposeFailed' => 'エラー: Docker コンテナの起動に失敗しました。',
 			'dev.start.stepDockerComposeStarted' => 'Docker コンテナを起動しました。',
 			'dev.start.stepOrchardWaiting' => 'Step 3: Orchard Controller の起動を待機中...',
@@ -205,10 +207,12 @@ extension on TranslationsJa {
 			'dev.start.stepOrchardContextRegistered' => 'Orchard CLI コンテキストを認証しました。',
 			'dev.start.stepOrchardWorker' => 'Mac側のOrchard Workerを起動します。Ctrl+Cで停止できます。Dockerコンテナは起動したままになります。',
 			'dev.start.stepOrchardWorkerFailed' => 'エラー: Orchard Workerを起動できなかったか、異常終了しました。',
-			'dev.start.stepSeed' => 'Step 5: ローカルテストデータを投入中...',
+			'dev.start.stepSeed' => 'Step 6: ローカルテストデータを投入中...',
 			'dev.start.stepSeedFailed' => 'エラー: ローカルテストデータの投入に失敗しました。',
 			'dev.start.stepSeedCompleted' => 'ローカルテストデータを投入しました。',
 			'dev.start.projectRootNotFound' => 'エラー: OpenCI プロジェクトのルートディレクトリが見つかりません。',
+			'dev.start.stepOrchardController' => 'Step 2: Orchard Controllerを起動中...',
+			'dev.start.stepBuildJobWorkerWaiting' => 'サービスを再起動する前に、実行中のビルドジョブの終了を待っています...',
 			'common.error' => ({required Object error}) => 'エラー: ${error}',
 			_ => null,
 		};

--- a/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/dev_start_command_test.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:genuineci_cli/src/commands/dev/dev_start_command.dart';
+import 'package:genuineci_cli/src/commands/dev/start_docker_compose.dart';
+import 'package:genuineci_cli/src/commands/dev/start_orchard_worker.dart';
 import 'package:genuineci_cli/src/i18n/i18n.dart';
 import 'package:test/test.dart';
 
@@ -18,6 +21,20 @@ class _RecordingLogger implements Logger {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _OrchardWorker implements OrchardWorker {
+  @override
+  bool isRunning = true;
+  bool stopped = false;
+  @override
+  Future<int> exitCode = Future.value(0);
+
+  @override
+  Future<void> stop() async {
+    stopped = true;
+    isRunning = false;
+  }
 }
 
 void main() {
@@ -49,13 +66,15 @@ void main() {
           logger: _RecordingLogger(),
           projectRootFinder: () => tempDirectory,
           tartBaseImageChecker: (_) async => true,
-          dockerComposeStarter: (_, _) async => true,
+          dockerComposeStarter:
+              (_, _, {step = DockerComposeStep.startServices}) async => true,
           orchardContextSetup: (_) async => true,
           localDataSeeder: (_) async {
             onSeed();
             return seedSucceeds;
           },
-          orchardWorkerStarter: orchardWorkerStarter ?? (_) async => 0,
+          orchardWorkerStarter:
+              orchardWorkerStarter ?? (_) async => _OrchardWorker(),
         ),
       );
 
@@ -108,20 +127,22 @@ void main() {
 
   test('returns 1 when seeding local data fails', () async {
     var seedCallCount = 0;
+    final worker = _OrchardWorker();
 
     final result = await runStart(
       shouldSeed: true,
       seedSucceeds: false,
       onSeed: () => seedCallCount++,
-      orchardWorkerStarter: (_) async => fail('Worker must not start'),
+      orchardWorkerStarter: (_) async => worker,
     );
 
     expect(result, equals(1));
     expect(seedCallCount, equals(1));
+    expect(worker.stopped, isTrue);
   });
 
   for (final shouldSeed in [false, true]) {
-    test('runs the worker after setup with seed=$shouldSeed', () async {
+    test('starts Orchard before draining (seed=$shouldSeed)', () async {
       final calls = <String>[];
       bool recordStep(String step) {
         calls.add(step);
@@ -129,19 +150,29 @@ void main() {
       }
 
       final logger = _RecordingLogger();
+      final worker = _OrchardWorker()..exitCode = Future.value(17);
       final runner = CommandRunner<int>('genuineci', 'CLI tool')
         ..addCommand(
           DevStartCommand(
             logger: logger,
             projectRootFinder: () => tempDirectory,
             tartBaseImageChecker: (_) async => recordStep('tart'),
-            dockerComposeStarter: (_, _) async => recordStep('compose'),
+            dockerComposeStarter:
+                (
+                  composeLogger,
+                  root, {
+                  step = DockerComposeStep.startServices,
+                }) async {
+                  expect(composeLogger, same(logger));
+                  expect(root, same(tempDirectory));
+                  return recordStep(step.name);
+                },
             orchardContextSetup: (_) async => recordStep('context'),
             localDataSeeder: (_) async => recordStep('seed'),
             orchardWorkerStarter: (workerLogger) async {
               expect(workerLogger, same(logger));
               calls.add('worker');
-              return 17;
+              return worker;
             },
           ),
         );
@@ -149,11 +180,14 @@ void main() {
       expect(await runner.run(['start', if (shouldSeed) '--seed']), 17);
       expect(calls, [
         'tart',
-        'compose',
+        'startOrchardController',
         'context',
-        if (shouldSeed) 'seed',
         'worker',
+        'stopBuildJobWorker',
+        'startServices',
+        if (shouldSeed) 'seed',
       ]);
+      expect(worker.stopped, isTrue);
     });
   }
 
@@ -163,12 +197,165 @@ void main() {
         logger: _RecordingLogger(),
         projectRootFinder: () => tempDirectory,
         tartBaseImageChecker: (_) async => failingStep != 'tart',
-        dockerComposeStarter: (_, _) async => failingStep != 'compose',
+        dockerComposeStarter:
+            (_, _, {step = DockerComposeStep.startServices}) async =>
+                failingStep != 'compose',
         orchardContextSetup: (_) async => failingStep != 'context',
         orchardWorkerStarter: (_) async => fail('Worker must not start'),
       ).run();
 
       expect(result, 1);
     });
+  }
+
+  test(
+    'does not stop app containers when the Mac worker cannot start',
+    () async {
+      final steps = <DockerComposeStep>[];
+      final result = await DevStartCommand(
+        logger: _RecordingLogger(),
+        projectRootFinder: () => tempDirectory,
+        tartBaseImageChecker: (_) async => true,
+        dockerComposeStarter:
+            (_, _, {step = DockerComposeStep.startServices}) async {
+              steps.add(step);
+              return true;
+            },
+        orchardContextSetup: (_) async => true,
+        orchardWorkerStarter: (_) async => null,
+      ).run();
+
+      expect(result, 1);
+      expect(steps, [DockerComposeStep.startOrchardController]);
+    },
+  );
+
+  test(
+    'waits for the old job before rebuilding and keeps Orchard alive',
+    () async {
+      final worker = _OrchardWorker();
+      final workerExit = Completer<int>();
+      worker.exitCode = workerExit.future;
+      final draining = Completer<void>();
+      final drained = Completer<bool>();
+      final rebuilt = Completer<void>();
+      var completed = false;
+      final result =
+          DevStartCommand(
+            logger: _RecordingLogger(),
+            projectRootFinder: () => tempDirectory,
+            tartBaseImageChecker: (_) async => true,
+            dockerComposeStarter:
+                (_, _, {step = DockerComposeStep.startServices}) async {
+                  if (step == DockerComposeStep.stopBuildJobWorker) {
+                    draining.complete();
+                    return drained.future;
+                  }
+                  if (step == DockerComposeStep.startServices) {
+                    expect(drained.isCompleted, isTrue);
+                    expect(worker.isRunning, isTrue);
+                    rebuilt.complete();
+                  }
+                  return true;
+                },
+            orchardContextSetup: (_) async => true,
+            orchardWorkerStarter: (_) async => worker,
+          ).run().then((code) {
+            completed = true;
+            return code;
+          });
+
+      await draining.future;
+      expect(rebuilt.isCompleted, isFalse);
+      expect(worker.stopped, isFalse);
+      drained.complete(true);
+      await rebuilt.future;
+      expect(completed, isFalse);
+      expect(worker.stopped, isFalse);
+      workerExit.complete(0);
+      expect(await result, 0);
+      expect(worker.stopped, isTrue);
+    },
+  );
+
+  for (final failedStep in [
+    DockerComposeStep.stopBuildJobWorker,
+    DockerComposeStep.startServices,
+  ]) {
+    for (final throwsError in [false, true]) {
+      test(
+        'stops Orchard when $failedStep fails (throws: $throwsError)',
+        () async {
+          final worker = _OrchardWorker();
+          final steps = <DockerComposeStep>[];
+          final runner = CommandRunner<int>('genuineci', 'CLI tool')
+            ..addCommand(
+              DevStartCommand(
+                logger: _RecordingLogger(),
+                projectRootFinder: () => tempDirectory,
+                tartBaseImageChecker: (_) async => true,
+                dockerComposeStarter:
+                    (_, _, {step = DockerComposeStep.startServices}) async {
+                      steps.add(step);
+                      if (step == failedStep && throwsError) {
+                        throw StateError('compose failed');
+                      }
+                      return step != failedStep;
+                    },
+                orchardContextSetup: (_) async => true,
+                orchardWorkerStarter: (_) async => worker,
+                localDataSeeder: (_) async =>
+                    fail('Must not seed after a failure'),
+              ),
+            );
+
+          final result = runner.run(['start', '--seed']);
+          if (throwsError) {
+            await expectLater(result, throwsStateError);
+          } else {
+            expect(await result, 1);
+          }
+          expect(steps, [
+            DockerComposeStep.startOrchardController,
+            DockerComposeStep.stopBuildJobWorker,
+            if (failedStep == DockerComposeStep.startServices)
+              DockerComposeStep.startServices,
+          ]);
+          expect(worker.stopped, isTrue);
+        },
+      );
+    }
+  }
+
+  for (final code in [0, 17, 130]) {
+    test(
+      'does not rebuild if Orchard exits while draining with code $code',
+      () async {
+        final worker = _OrchardWorker()..exitCode = Future.value(code);
+        final steps = <DockerComposeStep>[];
+        final result = await DevStartCommand(
+          logger: _RecordingLogger(),
+          projectRootFinder: () => tempDirectory,
+          tartBaseImageChecker: (_) async => true,
+          dockerComposeStarter:
+              (_, _, {step = DockerComposeStep.startServices}) async {
+                steps.add(step);
+                if (step == DockerComposeStep.stopBuildJobWorker) {
+                  worker.isRunning = false;
+                }
+                return true;
+              },
+          orchardContextSetup: (_) async => true,
+          orchardWorkerStarter: (_) async => worker,
+        ).run();
+
+        expect(result, code == 0 ? 1 : code);
+        expect(steps, [
+          DockerComposeStep.startOrchardController,
+          DockerComposeStep.stopBuildJobWorker,
+        ]);
+        expect(worker.stopped, isTrue);
+      },
+    );
   }
 }

--- a/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
@@ -29,6 +29,47 @@ void main() {
       projectRoot = Directory('/path/to/openci');
     });
 
+    for (final (step, arguments, message) in [
+      (
+        DockerComposeStep.startOrchardController,
+        ['compose', 'up', '-d', '--no-recreate', 'orchard-controller'],
+        t.dev.start.stepOrchardController,
+      ),
+      (
+        DockerComposeStep.stopBuildJobWorker,
+        ['compose', 'stop', 'build-job-worker'],
+        t.dev.start.stepBuildJobWorkerWaiting,
+      ),
+    ]) {
+      test('$step only touches the selected service', () async {
+        final calls = <List<String>>[];
+        final result = await startDockerCompose(
+          logger,
+          projectRoot,
+          step: step,
+          environment: const {'PATH': '/usr/local/bin'},
+          processRunner:
+              (
+                executable,
+                args, {
+                required workingDirectory,
+                required environment,
+              }) async {
+                expect(executable, 'docker');
+                expect(workingDirectory, projectRoot.path);
+                expect(environment, {'PATH': '/usr/local/bin'});
+                calls.add(args);
+                return 0;
+              },
+        );
+
+        expect(result, isTrue);
+        expect(calls, [arguments]);
+        expect(logger.stdoutMessages, ['\n$message']);
+        expect(logger.stderrMessages, isEmpty);
+      });
+    }
+
     test('starts worker services from the project root', () async {
       late String executable;
       final calls = <List<String>>[];

--- a/apps/genuineci_cli/test/src/commands/dev/start_orchard_worker_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_orchard_worker_test.dart
@@ -48,34 +48,36 @@ void main() {
   });
 
   test(
-    'runs the local worker with terminal output and waits for exit',
+    'starts the local worker with terminal output before waiting for exit',
     () async {
       final calls = <List<String>>[];
       final started = Completer<void>();
       var completed = false;
 
-      final result =
-          startOrchardWorker(
-            logger,
-            processRunner: (executable, arguments) async {
-              calls.add([executable, ...arguments]);
-              return ProcessResult(1, 0, '$token\n', '');
-            },
-            processStarter: (executable, arguments, {required mode}) async {
-              calls.add([executable, ...arguments]);
-              expect(mode, ProcessStartMode.inheritStdio);
-              started.complete();
-              return worker;
-            },
-          ).then((code) {
-            completed = true;
-            return code;
-          });
+      final result = await startOrchardWorker(
+        logger,
+        processRunner: (executable, arguments) async {
+          calls.add([executable, ...arguments]);
+          return ProcessResult(1, 0, '$token\n', '');
+        },
+        processStarter: (executable, arguments, {required mode}) async {
+          calls.add([executable, ...arguments]);
+          expect(mode, ProcessStartMode.inheritStdio);
+          started.complete();
+          return worker;
+        },
+      );
+      final exitCode = result!.exitCode.then((code) {
+        completed = true;
+        return code;
+      });
       await started.future;
+      expect(result.isRunning, isTrue);
       expect(completed, isFalse);
       worker.exited.complete(0);
 
-      expect(await result, 0);
+      expect(await exitCode, 0);
+      expect(result.isRunning, isFalse);
       expect(calls, [
         ['orchard', 'get', 'bootstrap-token', 'bootstrap-admin'],
         [
@@ -102,7 +104,8 @@ void main() {
         processStarter: (_, _, {required mode}) async => worker,
       );
 
-      expect(result, code == 17 ? 17 : 137);
+      expect(await result!.exitCode, code == 17 ? 17 : 137);
+      expect(result.isRunning, isFalse);
       expect(logger.stderrMessages, [t.dev.start.stepOrchardWorkerFailed]);
     });
   }
@@ -121,7 +124,7 @@ void main() {
               fail('Worker must not start'),
         );
 
-        expect(result, 1);
+        expect(result, isNull);
         expect(logger.stdoutMessages, isEmpty);
         expect(logger.stderrMessages, [t.dev.start.stepOrchardWorkerFailed]);
       },
@@ -145,7 +148,7 @@ void main() {
           },
         );
 
-        expect(result, 1);
+        expect(result, isNull);
         expect(logger.stderrMessages, [
           '${t.dev.start.stepOrchardWorkerFailed}\nnot found',
         ]);
@@ -166,27 +169,59 @@ void main() {
       addTearDown(terminations.close);
       var completed = false;
 
-      final result =
-          startOrchardWorker(
-            logger,
-            processRunner: (_, _) async => ProcessResult(1, 0, token, ''),
-            processStarter: (_, _, {required mode}) async => worker,
-            interruptSignals: interrupts.stream,
-            terminateSignals: terminations.stream,
-          ).then((code) {
-            completed = true;
-            return code;
-          });
+      final result = await startOrchardWorker(
+        logger,
+        processRunner: (_, _) async => ProcessResult(1, 0, token, ''),
+        processStarter: (_, _, {required mode}) async => worker,
+        interruptSignals: interrupts.stream,
+        terminateSignals: terminations.stream,
+      );
+      final exitCode = result!.exitCode.then((code) {
+        completed = true;
+        return code;
+      });
       await listening.future;
       (signal == ProcessSignal.sigint ? interrupts : terminations).add(signal);
 
       expect(worker.signals, [ProcessSignal.sigint]);
+      expect(result.isRunning, isFalse);
       expect(completed, isFalse);
       worker.exited.complete(1);
-      expect(await result, 128 + signal.signalNumber);
+      expect(await exitCode, 128 + signal.signalNumber);
+      expect(result.isRunning, isFalse);
+      await result.stop();
+      expect(worker.signals, [ProcessSignal.sigint]);
       expect(logger.stderrMessages, isEmpty);
       expect(interrupts.hasListener, isFalse);
       expect(terminations.hasListener, isFalse);
     });
   }
+
+  test('stop waits for cleanup and only sends one signal', () async {
+    final interrupts = StreamController<ProcessSignal>();
+    final terminations = StreamController<ProcessSignal>();
+    addTearDown(interrupts.close);
+    addTearDown(terminations.close);
+    final result = await startOrchardWorker(
+      logger,
+      processRunner: (_, _) async => ProcessResult(1, 0, token, ''),
+      processStarter: (_, _, {required mode}) async => worker,
+      interruptSignals: interrupts.stream,
+      terminateSignals: terminations.stream,
+    );
+    var stopped = false;
+    final stopping = result!.stop().then((_) => stopped = true);
+    final alsoStopping = result.stop();
+
+    expect(result.isRunning, isFalse);
+    expect(stopped, isFalse);
+    expect(worker.signals, [ProcessSignal.sigint]);
+    worker.exited.complete(1);
+    await stopping;
+    await alsoStopping;
+    expect(stopped, isTrue);
+    expect(interrupts.hasListener, isFalse);
+    expect(terminations.hasListener, isFalse);
+    expect(logger.stderrMessages, isEmpty);
+  });
 }


### PR DESCRIPTION
…se integration

- Updated README.md to clarify the startup process for Orchard Controller and Mac worker.
- Modified i18n files (en and ja) to reflect changes in Docker Compose steps and added new messages for Orchard Controller startup and build job worker waiting.
- Refactored dev_start_command.dart to improve the orchestration of Docker Compose and Orchard Worker, ensuring the old build job worker is stopped before restarting services.
- Enhanced start_docker_compose.dart to support step-based execution for Docker Compose commands.
- Updated start_orchard_worker.dart to return a more structured OrchardWorker object and handle signals appropriately.
- Adjusted tests in dev_start_command_test.dart and start_orchard_worker_test.dart to validate the new workflow and ensure proper cleanup and signal handling.
- Regenerated strings files to include new translations and updated string counts.