### PR TITLE
feat(worker): add Orchard worker listing API

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -28,6 +28,8 @@ Composeでは`build-job-worker`を常駐サービスとして起動します。
 `BUILD_JOB_ID`は不要です。Orchardの認証情報は環境変数から読み込みます。
 
 `OrchardApiClient(config: config)`でクライアントを作成し、使用後に`close()`を呼び出します。
+`listWorkers()`は`GET /v1/workers`からworker一覧を取得し、各workerの情報をそのまま返します。
+HTTP失敗・不正なレスポンスは例外にし、応答待ちは標準10秒でタイムアウトします。
 `waitForVmRunning()`は標準で3秒間隔・最大5分間、`running`または`active`になるまで待機します。
 HTTP応答待ちも制限時間に含み、APIエラーは呼び出し元へ返します。
 `prepareVm()`はVMを作成し、標準で最大15分の起動待ちを行ってVM情報を返します。

--- a/apps/build_job_worker/lib/src/orchard/orchard_api_client.dart
+++ b/apps/build_job_worker/lib/src/orchard/orchard_api_client.dart
@@ -50,6 +50,21 @@ class OrchardApiClient {
     };
   }
 
+  Future<List<Map<String, dynamic>>> listWorkers({
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    final response = await _httpClient
+        .get(_apiUri('workers'), headers: _headers)
+        .timeout(timeout);
+    _checkResponse(response, 'list Orchard workers');
+    final workers = jsonDecode(response.body);
+    if (workers is! List<dynamic> ||
+        workers.any((worker) => worker is! Map<String, dynamic>)) {
+      throw const FormatException('Orchard workers must be a list of objects.');
+    }
+    return workers.cast<Map<String, dynamic>>();
+  }
+
   Future<OrchardLease> createLease({
     required String imageName,
     String? vmName,
@@ -208,14 +223,16 @@ class OrchardApiClient {
   /// Closes the HTTP client, including an injected client.
   void close() => _httpClient.close();
 
-  Uri _vmUri([String? leaseId]) {
+  Uri _vmUri([String? leaseId]) => _apiUri('vms', leaseId);
+
+  Uri _apiUri(String resource, [String? id]) {
     final baseUri = Uri.parse(_config.orchardApiUrl);
     return baseUri.replace(
       pathSegments: [
         ...baseUri.pathSegments.where((segment) => segment.isNotEmpty),
         'v1',
-        'vms',
-        ?leaseId,
+        resource,
+        ?id,
       ],
     );
   }

--- a/apps/build_job_worker/test/src/orchard/orchard_api_client_test.dart
+++ b/apps/build_job_worker/test/src/orchard/orchard_api_client_test.dart
@@ -19,6 +19,51 @@ const _config = Config(
 
 void main() {
   group('OrchardApiClient', () {
+    group('listWorkers', () {
+      for (final workers in <List<Map<String, dynamic>>>[
+        [],
+        [
+          {
+            'name': 'mac-1',
+            'resources': {'org.cirruslabs.tart-vms': 2},
+          },
+          {'name': 'mac-2', 'scheduling_paused': true},
+        ],
+      ]) {
+        test('returns ${workers.length} worker records', () async {
+          final client = _createClient((request) async {
+            expect(request.method, 'GET');
+            expect(
+              request.url.toString(),
+              'https://orchard.example.com:6120/v1/workers',
+            );
+            return http.Response(jsonEncode(workers), 200);
+          });
+
+          expect(await client.listWorkers(), workers);
+        });
+      }
+
+      for (final body in ['invalid', '{}', 'null', '[null]']) {
+        test('rejects a malformed worker list: $body', () async {
+          final client = _createClient((_) async => http.Response(body, 200));
+
+          await expectLater(client.listWorkers(), throwsFormatException);
+        });
+      }
+
+      test('times out a stalled request', () async {
+        final response = Completer<http.Response>();
+        final client = _createClient((_) => response.future);
+        addTearDown(() => response.complete(http.Response('[]', 200)));
+
+        await expectLater(
+          client.listWorkers(timeout: const Duration(milliseconds: 10)),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
     test('creates a VM with its image and resource requirements', () async {
       final client = _createClient((request) async {
         expect(request.method, 'POST');
@@ -201,6 +246,7 @@ void main() {
     });
 
     final operations = <String, Future<void> Function(OrchardApiClient)>{
+      'listWorkers': (client) => client.listWorkers(),
       'createLease': (client) => client.createLease(imageName: 'base-macos'),
       'getLease': (client) => client.getLease('lease-1'),
       'deleteLease': (client) => client.deleteLease('lease-1'),
@@ -229,6 +275,7 @@ void main() {
       final error = http.ClientException('Connection failed');
       final client = _createClient((_) async => throw error);
 
+      await expectLater(client.listWorkers(), throwsA(same(error)));
       await expectLater(client.getLease('lease-1'), throwsA(same(error)));
       await expectLater(
         client.waitForVmRunning('lease-1'),


### PR DESCRIPTION
Orchardの実行可能数を調べるための入口として、既存の認証付きクライアントに`listWorkers()`を追加します。`GET /v1/workers`の情報を返し、不正なレスポンス・HTTPエラー・通信エラー・タイムアウトを扱います。

このPRはAPI取得・テスト・READMEの3ファイルに限定しています。実行可能数の計算と並列実行ループへの接続は後続のPRで追加します。

検証:

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test test integration_test`
- 差分全体のレビューと`git diff --check`
