### PR TITLE
feat(worker): calculate job capacity from Orchard resources

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -30,6 +30,9 @@ Composeでは`build-job-worker`を常駐サービスとして起動します。
 `OrchardApiClient(config: config)`でクライアントを作成し、使用後に`close()`を呼び出します。
 `listWorkers()`は`GET /v1/workers`からworker一覧を取得し、各workerの情報をそのまま返します。
 HTTP失敗・不正なレスポンスは例外にし、応答待ちは標準10秒でタイムアウトします。
+`calculateMaxConcurrentJobs()`はworker一覧、1 jobのCPU数・メモリ（GiB）、現在時刻から実行可能数を計算します。
+workerごとのVM枠・CPU・メモリの制約を反映し、停止中・最終heartbeatから3分超・Tart/arm64以外のworkerを除外します。
+返す値は総実行枠です。実行中jobの差し引きと実行ループへの接続は呼び出し側で行います。
 `waitForVmRunning()`は標準で3秒間隔・最大5分間、`running`または`active`になるまで待機します。
 HTTP応答待ちも制限時間に含み、APIエラーは呼び出し元へ返します。
 `prepareVm()`はVMを作成し、標準で最大15分の起動待ちを行ってVM情報を返します。

--- a/apps/build_job_worker/lib/build_job_worker.dart
+++ b/apps/build_job_worker/lib/build_job_worker.dart
@@ -8,6 +8,7 @@ export 'src/create_build_run.dart';
 export 'src/execute_build_job.dart';
 export 'src/fetch_job_secrets.dart';
 export 'src/loki/push_log_to_loki.dart';
+export 'src/orchard/calculate_max_concurrent_jobs.dart';
 export 'src/orchard/execute_command.dart';
 export 'src/orchard/orchard_api_client.dart';
 export 'src/orchard/prepare_vm.dart';

--- a/apps/build_job_worker/lib/build_job_worker.dart
+++ b/apps/build_job_worker/lib/build_job_worker.dart
@@ -8,7 +8,8 @@ export 'src/create_build_run.dart';
 export 'src/execute_build_job.dart';
 export 'src/fetch_job_secrets.dart';
 export 'src/loki/push_log_to_loki.dart';
-export 'src/orchard/calculate_max_concurrent_jobs.dart';
+export 'src/orchard/calculate_max_concurrent_jobs.dart'
+    show calculateMaxConcurrentJobs;
 export 'src/orchard/execute_command.dart';
 export 'src/orchard/orchard_api_client.dart';
 export 'src/orchard/prepare_vm.dart';

--- a/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
+++ b/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
@@ -10,32 +10,44 @@ int calculateMaxConcurrentJobs({
   if (cpuCount <= 0 || memoryGb <= 0) {
     throw ArgumentError('VM CPU and memory must be positive.');
   }
-  // Matches Orchard Controller's default workerOfflineTimeout.
-  final cutoff = now.subtract(const Duration(minutes: 3));
   var capacity = 0;
   for (final worker in workers) {
-    if ((worker['scheduling_paused'] as bool? ?? false) ||
-        (worker['runtime'] as String? ?? 'tart') != 'tart' ||
-        (worker['arch'] as String? ?? 'arm64') != 'arm64') {
-      continue;
-    }
-    final lastSeen = DateTime.tryParse(worker['last_seen'] as String? ?? '');
-    if (lastSeen == null || lastSeen.isBefore(cutoff)) continue;
-    final resources = worker['resources'];
-    if (resources is! Map<String, dynamic>) continue;
-
-    int resource(String name) {
-      final value = resources[name];
-      return value is int && value > 0 ? value : 0;
-    }
-
-    capacity += min(
-      resource('org.cirruslabs.tart-vms'),
-      min(
-        resource('org.cirruslabs.logical-cores') ~/ cpuCount,
-        resource('org.cirruslabs.memory-mib') ~/ (memoryGb * 1024),
-      ),
-    );
+    if (!_isWorkerAvailable(worker, now)) continue;
+    capacity += _calculateWorkerCapacity(worker, cpuCount, memoryGb);
   }
   return capacity;
+}
+
+bool _isWorkerAvailable(Map<String, dynamic> worker, DateTime now) {
+  if ((worker['scheduling_paused'] as bool? ?? false) ||
+      (worker['runtime'] as String? ?? 'tart') != 'tart' ||
+      (worker['arch'] as String? ?? 'arm64') != 'arm64') {
+    return false;
+  }
+  // Matches Orchard Controller's default workerOfflineTimeout.
+  final cutoff = now.subtract(const Duration(minutes: 3));
+  final lastSeen = DateTime.tryParse(worker['last_seen'] as String? ?? '');
+  return lastSeen != null && !lastSeen.isBefore(cutoff);
+}
+
+int _calculateWorkerCapacity(
+  Map<String, dynamic> worker,
+  int cpuCount,
+  int memoryGb,
+) {
+  final resources = worker['resources'];
+  if (resources is! Map<String, dynamic>) return 0;
+
+  final vmSlots = _readResource(resources, 'org.cirruslabs.tart-vms');
+  final cpuSlots =
+      _readResource(resources, 'org.cirruslabs.logical-cores') ~/ cpuCount;
+  final memorySlots =
+      _readResource(resources, 'org.cirruslabs.memory-mib') ~/
+      (memoryGb * 1024);
+  return min(vmSlots, min(cpuSlots, memorySlots));
+}
+
+int _readResource(Map<String, dynamic> resources, String name) {
+  final value = resources[name];
+  return value is int && value > 0 ? value : 0;
 }

--- a/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
+++ b/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
@@ -1,5 +1,7 @@
 import 'dart:math';
 
+import 'package:meta/meta.dart';
+
 /// Total job capacity; currently running jobs must be counted by the caller.
 int calculateMaxConcurrentJobs({
   required List<Map<String, dynamic>> workers,
@@ -12,13 +14,14 @@ int calculateMaxConcurrentJobs({
   }
   var capacity = 0;
   for (final worker in workers) {
-    if (!_isWorkerAvailable(worker, now)) continue;
-    capacity += _calculateWorkerCapacity(worker, cpuCount, memoryGb);
+    if (!isWorkerAvailable(worker, now)) continue;
+    capacity += calculateWorkerCapacity(worker, cpuCount, memoryGb);
   }
   return capacity;
 }
 
-bool _isWorkerAvailable(Map<String, dynamic> worker, DateTime now) {
+@visibleForTesting
+bool isWorkerAvailable(Map<String, dynamic> worker, DateTime now) {
   if ((worker['scheduling_paused'] as bool? ?? false) ||
       (worker['runtime'] as String? ?? 'tart') != 'tart' ||
       (worker['arch'] as String? ?? 'arm64') != 'arm64') {
@@ -30,7 +33,8 @@ bool _isWorkerAvailable(Map<String, dynamic> worker, DateTime now) {
   return lastSeen != null && !lastSeen.isBefore(cutoff);
 }
 
-int _calculateWorkerCapacity(
+@visibleForTesting
+int calculateWorkerCapacity(
   Map<String, dynamic> worker,
   int cpuCount,
   int memoryGb,
@@ -38,16 +42,16 @@ int _calculateWorkerCapacity(
   final resources = worker['resources'];
   if (resources is! Map<String, dynamic>) return 0;
 
-  final vmSlots = _readResource(resources, 'org.cirruslabs.tart-vms');
+  final vmSlots = readResource(resources, 'org.cirruslabs.tart-vms');
   final cpuSlots =
-      _readResource(resources, 'org.cirruslabs.logical-cores') ~/ cpuCount;
+      readResource(resources, 'org.cirruslabs.logical-cores') ~/ cpuCount;
   final memorySlots =
-      _readResource(resources, 'org.cirruslabs.memory-mib') ~/
-      (memoryGb * 1024);
+      readResource(resources, 'org.cirruslabs.memory-mib') ~/ (memoryGb * 1024);
   return min(vmSlots, min(cpuSlots, memorySlots));
 }
 
-int _readResource(Map<String, dynamic> resources, String name) {
+@visibleForTesting
+int readResource(Map<String, dynamic> resources, String name) {
   final value = resources[name];
   return value is int && value > 0 ? value : 0;
 }

--- a/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
+++ b/apps/build_job_worker/lib/src/orchard/calculate_max_concurrent_jobs.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+
+/// Total job capacity; currently running jobs must be counted by the caller.
+int calculateMaxConcurrentJobs({
+  required List<Map<String, dynamic>> workers,
+  required int cpuCount,
+  required int memoryGb,
+  required DateTime now,
+}) {
+  if (cpuCount <= 0 || memoryGb <= 0) {
+    throw ArgumentError('VM CPU and memory must be positive.');
+  }
+  // Matches Orchard Controller's default workerOfflineTimeout.
+  final cutoff = now.subtract(const Duration(minutes: 3));
+  var capacity = 0;
+  for (final worker in workers) {
+    if ((worker['scheduling_paused'] as bool? ?? false) ||
+        (worker['runtime'] as String? ?? 'tart') != 'tart' ||
+        (worker['arch'] as String? ?? 'arm64') != 'arm64') {
+      continue;
+    }
+    final lastSeen = DateTime.tryParse(worker['last_seen'] as String? ?? '');
+    if (lastSeen == null || lastSeen.isBefore(cutoff)) continue;
+    final resources = worker['resources'];
+    if (resources is! Map<String, dynamic>) continue;
+
+    int resource(String name) {
+      final value = resources[name];
+      return value is int && value > 0 ? value : 0;
+    }
+
+    capacity += min(
+      resource('org.cirruslabs.tart-vms'),
+      min(
+        resource('org.cirruslabs.logical-cores') ~/ cpuCount,
+        resource('org.cirruslabs.memory-mib') ~/ (memoryGb * 1024),
+      ),
+    );
+  }
+  return capacity;
+}

--- a/apps/build_job_worker/pubspec.yaml
+++ b/apps/build_job_worker/pubspec.yaml
@@ -10,6 +10,7 @@ resolution: workspace
 
 dependencies:
   http: ^1.6.0
+  meta: ^1.16.0
   openci_shared: ^1.0.1
   sentry: ^9.22.0
 

--- a/apps/build_job_worker/test/src/orchard/calculate_max_concurrent_jobs_test.dart
+++ b/apps/build_job_worker/test/src/orchard/calculate_max_concurrent_jobs_test.dart
@@ -1,0 +1,112 @@
+import 'package:build_job_worker/build_job_worker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 9, 10);
+  final worker = <String, dynamic>{
+    'name': 'mac-1',
+    'last_seen': now.toIso8601String(),
+    'resources': {
+      'org.cirruslabs.tart-vms': 2,
+      'org.cirruslabs.logical-cores': 8,
+      'org.cirruslabs.memory-mib': 16384,
+    },
+  };
+  int capacity(
+    List<Map<String, dynamic>> workers, {
+    int cpu = 2,
+    int memory = 4,
+  }) => calculateMaxConcurrentJobs(
+    workers: workers,
+    cpuCount: cpu,
+    memoryGb: memory,
+    now: now,
+  );
+
+  group('calculateMaxConcurrentJobs', () {
+    test('sums capacity per worker, including an empty cluster', () {
+      final workers = [
+        worker,
+        {...worker, 'name': 'mac-2'},
+      ];
+      expect(capacity([]), 0);
+      expect(capacity(workers), 4);
+      expect(capacity(workers, cpu: 5), 2);
+    });
+
+    for (final (cpu, memory, expected) in [
+      (2, 4, 2),
+      (5, 4, 1),
+      (2, 12, 1),
+      (9, 4, 0),
+      (2, 17, 0),
+    ]) {
+      test('fits jobs requesting $cpu CPUs and $memory GiB', () {
+        expect(capacity([worker], cpu: cpu, memory: memory), expected);
+      });
+    }
+
+    for (final (reason, fields) in <(String, Map<String, dynamic>)>[
+      ('paused', {'scheduling_paused': true}),
+      (
+        'offline',
+        {
+          'last_seen': now
+              .subtract(const Duration(minutes: 3, seconds: 1))
+              .toIso8601String(),
+        },
+      ),
+      ('missing heartbeat', {'last_seen': null}),
+      ('invalid heartbeat', {'last_seen': 'invalid'}),
+      ('incompatible runtime', {'runtime': 'vetu'}),
+      ('incompatible architecture', {'arch': 'amd64'}),
+      ('missing resources', {'resources': null}),
+      ('empty resources', {'resources': <String, dynamic>{}}),
+      (
+        'invalid resources',
+        {
+          'resources': {'org.cirruslabs.tart-vms': '2'},
+        },
+      ),
+      (
+        'negative resources',
+        {
+          'resources': {'org.cirruslabs.tart-vms': -1},
+        },
+      ),
+    ]) {
+      test('ignores a worker with $reason', () {
+        expect(
+          capacity([
+            {...worker, ...fields},
+            worker,
+          ]),
+          2,
+        );
+      });
+    }
+
+    test('accepts the offline boundary and timestamp offsets', () {
+      for (final timestamp in [
+        now.subtract(const Duration(minutes: 3)).toIso8601String(),
+        '2026-09-10T09:00:00+09:00',
+      ]) {
+        expect(
+          capacity([
+            {...worker, 'last_seen': timestamp},
+          ]),
+          2,
+        );
+      }
+    });
+
+    for (final (cpu, memory) in [(0, 4), (-1, 4), (2, 0), (2, -1)]) {
+      test('rejects a VM size of $cpu CPUs and $memory GiB', () {
+        expect(
+          () => capacity([], cpu: cpu, memory: memory),
+          throwsArgumentError,
+        );
+      });
+    }
+  });
+}

--- a/apps/build_job_worker/test/src/orchard/calculate_max_concurrent_jobs_test.dart
+++ b/apps/build_job_worker/test/src/orchard/calculate_max_concurrent_jobs_test.dart
@@ -1,16 +1,19 @@
 import 'package:build_job_worker/build_job_worker.dart';
+import 'package:build_job_worker/src/orchard/calculate_max_concurrent_jobs.dart'
+    show calculateWorkerCapacity, isWorkerAvailable, readResource;
 import 'package:test/test.dart';
 
 void main() {
   final now = DateTime.utc(2026, 9, 10);
+  const resources = <String, dynamic>{
+    'org.cirruslabs.tart-vms': 2,
+    'org.cirruslabs.logical-cores': 8,
+    'org.cirruslabs.memory-mib': 16384,
+  };
   final worker = <String, dynamic>{
     'name': 'mac-1',
     'last_seen': now.toIso8601String(),
-    'resources': {
-      'org.cirruslabs.tart-vms': 2,
-      'org.cirruslabs.logical-cores': 8,
-      'org.cirruslabs.memory-mib': 16384,
-    },
+    'resources': resources,
   };
   int capacity(
     List<Map<String, dynamic>> workers, {
@@ -34,17 +37,40 @@ void main() {
       expect(capacity(workers, cpu: 5), 2);
     });
 
-    for (final (cpu, memory, expected) in [
-      (2, 4, 2),
-      (5, 4, 1),
-      (2, 12, 1),
-      (9, 4, 0),
-      (2, 17, 0),
-    ]) {
-      test('fits jobs requesting $cpu CPUs and $memory GiB', () {
-        expect(capacity([worker], cpu: cpu, memory: memory), expected);
+    test('excludes unavailable workers and workers without capacity', () {
+      expect(
+        capacity([
+          {...worker, 'scheduling_paused': true},
+          {...worker, 'resources': null},
+          worker,
+        ]),
+        2,
+      );
+    });
+
+    for (final (cpu, memory) in [(0, 4), (-1, 4), (2, 0), (2, -1)]) {
+      test('rejects a VM size of $cpu CPUs and $memory GiB', () {
+        expect(
+          () => capacity([], cpu: cpu, memory: memory),
+          throwsArgumentError,
+        );
       });
     }
+  });
+
+  group('isWorkerAvailable', () {
+    test('accepts default and explicit scheduling fields', () {
+      expect(isWorkerAvailable(worker, now), isTrue);
+      expect(
+        isWorkerAvailable({
+          ...worker,
+          'scheduling_paused': false,
+          'runtime': 'tart',
+          'arch': 'arm64',
+        }, now),
+        isTrue,
+      );
+    });
 
     for (final (reason, fields) in <(String, Map<String, dynamic>)>[
       ('paused', {'scheduling_paused': true}),
@@ -52,7 +78,7 @@ void main() {
         'offline',
         {
           'last_seen': now
-              .subtract(const Duration(minutes: 3, seconds: 1))
+              .subtract(const Duration(minutes: 3, microseconds: 1))
               .toIso8601String(),
         },
       ),
@@ -60,29 +86,9 @@ void main() {
       ('invalid heartbeat', {'last_seen': 'invalid'}),
       ('incompatible runtime', {'runtime': 'vetu'}),
       ('incompatible architecture', {'arch': 'amd64'}),
-      ('missing resources', {'resources': null}),
-      ('empty resources', {'resources': <String, dynamic>{}}),
-      (
-        'invalid resources',
-        {
-          'resources': {'org.cirruslabs.tart-vms': '2'},
-        },
-      ),
-      (
-        'negative resources',
-        {
-          'resources': {'org.cirruslabs.tart-vms': -1},
-        },
-      ),
     ]) {
-      test('ignores a worker with $reason', () {
-        expect(
-          capacity([
-            {...worker, ...fields},
-            worker,
-          ]),
-          2,
-        );
+      test('rejects a worker with $reason', () {
+        expect(isWorkerAvailable({...worker, ...fields}, now), isFalse);
       });
     }
 
@@ -92,20 +98,68 @@ void main() {
         '2026-09-10T09:00:00+09:00',
       ]) {
         expect(
-          capacity([
-            {...worker, 'last_seen': timestamp},
-          ]),
-          2,
+          isWorkerAvailable({...worker, 'last_seen': timestamp}, now),
+          isTrue,
         );
       }
     });
+  });
 
-    for (final (cpu, memory) in [(0, 4), (-1, 4), (2, 0), (2, -1)]) {
-      test('rejects a VM size of $cpu CPUs and $memory GiB', () {
+  group('calculateWorkerCapacity', () {
+    for (final (cpu, memory, expected) in [
+      (2, 4, 2),
+      (5, 4, 1),
+      (2, 12, 1),
+      (9, 4, 0),
+      (2, 17, 0),
+    ]) {
+      test('fits jobs requesting $cpu CPUs and $memory GiB', () {
+        expect(calculateWorkerCapacity(worker, cpu, memory), expected);
+      });
+    }
+
+    for (final (reason, value) in <(String, Object?)>[
+      ('missing', null),
+      ('invalid', 'invalid'),
+      ('empty', <String, dynamic>{}),
+    ]) {
+      test('returns zero for $reason resources', () {
         expect(
-          () => capacity([], cpu: cpu, memory: memory),
-          throwsArgumentError,
+          calculateWorkerCapacity({...worker, 'resources': value}, 2, 4),
+          0,
         );
+      });
+    }
+
+    for (final name in resources.keys) {
+      test('returns zero when $name is missing', () {
+        expect(
+          calculateWorkerCapacity(
+            {
+              ...worker,
+              'resources': {...resources}..remove(name),
+            },
+            2,
+            4,
+          ),
+          0,
+        );
+      });
+    }
+  });
+
+  group('readResource', () {
+    test('reads the requested positive integer', () {
+      expect(readResource({'vm': 2, 'cpu': 8}, 'cpu'), 8);
+    });
+
+    test('returns zero for a missing resource', () {
+      expect(readResource({}, 'cpu'), 0);
+    });
+
+    for (final value in <Object?>[null, 0, -1, 2.5, '2', true]) {
+      test('returns zero for $value (${value.runtimeType})', () {
+        expect(readResource({'cpu': value}, 'cpu'), 0);
       });
     }
   });


### PR DESCRIPTION
Orchardのworker情報から同時実行可能数を計算する`calculateMaxConcurrentJobs()`を追加します。workerごとにVM枠・CPU・メモリの制約を適用して合計し、停止中・オフライン・Tart/arm64以外のworkerを除外します。

worker一覧、1 jobのCPU数・メモリ、現在時刻を引数で受け取る計算関数です。返す値は総実行枠で、実行中jobの差し引きと実行ループへの接続は後続の変更に分けています。

利用可否判定・1台分の容量計算・リソース値の取得を補助関数に分け、`@visibleForTesting`を付けて各関数を直接unit testで検証します。公開関数には集計と入力検証のテストを残しています。

検証:

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test test integration_test`
- 差分全体のレビューと`git diff --cached --check`
