### PR TITLE
feat(worker): expose Orchard capacity through API client

### DIFF
--- a/apps/build_job_worker/README.md
+++ b/apps/build_job_worker/README.md
@@ -33,13 +33,15 @@ HTTP失敗・不正なレスポンスは例外にし、応答待ちは標準10�
 `calculateMaxConcurrentJobs()`はworker一覧、1 jobのCPU数・メモリ（GiB）、現在時刻から実行可能数を計算します。
 workerごとのVM枠・CPU・メモリの制約を反映し、停止中・最終heartbeatから3分超・Tart/arm64以外のworkerを除外します。
 返す値は総実行枠です。実行中jobの差し引きと実行ループへの接続は呼び出し側で行います。
+`OrchardApiClient.getMaxConcurrentJobs()`はworker一覧を取得し、この計算関数で総実行枠を返します。
+CPU・メモリの既定値はVM作成と共通です。HTTP失敗・不正な応答・タイムアウトは呼び出し元へ返します。
 `waitForVmRunning()`は標準で3秒間隔・最大5分間、`running`または`active`になるまで待機します。
 HTTP応答待ちも制限時間に含み、APIエラーは呼び出し元へ返します。
 `prepareVm()`はVMを作成し、標準で最大15分の起動待ちを行ってVM情報を返します。
 起動待ちが失敗した場合は作成済みVMの削除を試み、削除も失敗した場合は両方の原因を返します。
 `execCommandWebSocket()`はVM内でコマンドを実行し、`onLog(line, stream)`にstdout・stderrを行単位で通知して終了コードを返します。
 終了通知前の切断や不正なレスポンスはエラーにし、処理終了時に接続を閉じます。
-VMのCPU数・メモリは`createLease()`の引数、`ORCHARD_VM_CPU`・`ORCHARD_VM_MEMORY_GB`、
+VMのCPU数・メモリは`createLease()`・`getMaxConcurrentJobs()`の引数、`ORCHARD_VM_CPU`・`ORCHARD_VM_MEMORY_GB`、
 デフォルト値（2コア・4 GiB）の順に決まります。
 ローカルOrchardの`--no-pki`構成に対応します。
 証明書の例外許可は設定した接続先のホスト・ポートに限定します。

--- a/apps/build_job_worker/lib/src/orchard/orchard_api_client.dart
+++ b/apps/build_job_worker/lib/src/orchard/orchard_api_client.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 
 import '../config.dart';
+import 'calculate_max_concurrent_jobs.dart' show calculateMaxConcurrentJobs;
 
 class OrchardLease {
   const OrchardLease({
@@ -41,6 +42,12 @@ class OrchardApiClient {
   final Config _config;
   final http.Client _httpClient;
 
+  int get _defaultCpuCount =>
+      int.tryParse(Platform.environment['ORCHARD_VM_CPU'] ?? '') ?? 2;
+
+  int get _defaultMemoryGb =>
+      int.tryParse(Platform.environment['ORCHARD_VM_MEMORY_GB'] ?? '') ?? 4;
+
   Map<String, String> get _headers {
     final credentials =
         '${_config.orchardServiceAccountName}:${_config.orchardServiceAccountToken}';
@@ -65,6 +72,22 @@ class OrchardApiClient {
     return workers.cast<Map<String, dynamic>>();
   }
 
+  /// Total job capacity using the same VM size defaults as [createLease].
+  /// Currently running jobs must be counted by the caller.
+  Future<int> getMaxConcurrentJobs({
+    int? cpuCount,
+    int? memoryGb,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    final workers = await listWorkers(timeout: timeout);
+    return calculateMaxConcurrentJobs(
+      workers: workers,
+      cpuCount: cpuCount ?? _defaultCpuCount,
+      memoryGb: memoryGb ?? _defaultMemoryGb,
+      now: DateTime.now().toUtc(),
+    );
+  }
+
   Future<OrchardLease> createLease({
     required String imageName,
     String? vmName,
@@ -73,15 +96,8 @@ class OrchardApiClient {
     bool headless = true,
     String os = 'darwin',
   }) async {
-    final cpu =
-        cpuCount ??
-        int.tryParse(Platform.environment['ORCHARD_VM_CPU'] ?? '') ??
-        2;
-    final memoryMiB =
-        (memoryGb ??
-            int.tryParse(Platform.environment['ORCHARD_VM_MEMORY_GB'] ?? '') ??
-            4) *
-        1024;
+    final cpu = cpuCount ?? _defaultCpuCount;
+    final memoryMiB = (memoryGb ?? _defaultMemoryGb) * 1024;
     final response = await _httpClient.post(
       _vmUri(),
       headers: _headers,

--- a/apps/build_job_worker/test/src/orchard/orchard_api_client_test.dart
+++ b/apps/build_job_worker/test/src/orchard/orchard_api_client_test.dart
@@ -64,6 +64,97 @@ void main() {
       });
     });
 
+    group('getMaxConcurrentJobs', () {
+      for (final (cpu, memory, expected) in [
+        (2, 4, 4),
+        (5, 4, 2),
+        (2, 12, 2),
+      ]) {
+        test('calculates capacity for $cpu CPUs and $memory GiB', () async {
+          final workers = [
+            for (final name in ['mac-1', 'mac-2'])
+              {
+                'name': name,
+                'last_seen': DateTime.now().toUtc().toIso8601String(),
+                'resources': {
+                  'org.cirruslabs.tart-vms': 2,
+                  'org.cirruslabs.logical-cores': 8,
+                  'org.cirruslabs.memory-mib': 16384,
+                },
+              },
+          ];
+          final client = _createClient((request) async {
+            expect(request.method, 'GET');
+            expect(request.url.path, '/v1/workers');
+            return http.Response(jsonEncode(workers), 200);
+          });
+
+          expect(
+            await client.getMaxConcurrentJobs(cpuCount: cpu, memoryGb: memory),
+            expected,
+          );
+        });
+      }
+
+      test('returns zero for an empty cluster', () async {
+        final client = _createClient((_) async => http.Response('[]', 200));
+
+        expect(await client.getMaxConcurrentJobs(cpuCount: 2, memoryGb: 4), 0);
+      });
+
+      test('shares CPU and memory defaults with VM creation', () async {
+        late Map<String, dynamic> resources;
+        final client = _createClient((request) async {
+          if (request.method == 'POST') {
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            resources = body['resources'] as Map<String, dynamic>;
+            return _leaseResponse('pending');
+          }
+          return http.Response(
+            jsonEncode([
+              {
+                'last_seen': DateTime.now().toUtc().toIso8601String(),
+                'resources': resources,
+              },
+            ]),
+            200,
+          );
+        });
+
+        await client.createLease(imageName: 'base-macos');
+        final vmResources = resources;
+        for (final limit in [
+          'org.cirruslabs.logical-cores',
+          'org.cirruslabs.memory-mib',
+        ]) {
+          resources = vmResources.map(
+            (name, value) =>
+                MapEntry(name, name == limit ? value : (value as int) * 2),
+          );
+          expect(await client.getMaxConcurrentJobs(), 1, reason: limit);
+        }
+      });
+
+      test('propagates a malformed worker response', () async {
+        final client = _createClient((_) async => http.Response('{}', 200));
+
+        await expectLater(client.getMaxConcurrentJobs(), throwsFormatException);
+      });
+
+      test('uses the supplied request timeout', () async {
+        final response = Completer<http.Response>();
+        final client = _createClient((_) => response.future);
+        addTearDown(() => response.complete(http.Response('[]', 200)));
+
+        await expectLater(
+          client.getMaxConcurrentJobs(
+            timeout: const Duration(milliseconds: 10),
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
     test('creates a VM with its image and resource requirements', () async {
       final client = _createClient((request) async {
         expect(request.method, 'POST');
@@ -247,6 +338,7 @@ void main() {
 
     final operations = <String, Future<void> Function(OrchardApiClient)>{
       'listWorkers': (client) => client.listWorkers(),
+      'getMaxConcurrentJobs': (client) => client.getMaxConcurrentJobs(),
       'createLease': (client) => client.createLease(imageName: 'base-macos'),
       'getLease': (client) => client.getLease('lease-1'),
       'deleteLease': (client) => client.deleteLease('lease-1'),
@@ -276,6 +368,7 @@ void main() {
       final client = _createClient((_) async => throw error);
 
       await expectLater(client.listWorkers(), throwsA(same(error)));
+      await expectLater(client.getMaxConcurrentJobs(), throwsA(same(error)));
       await expectLater(client.getLease('lease-1'), throwsA(same(error)));
       await expectLater(
         client.waitForVmRunning('lease-1'),


### PR DESCRIPTION
`OrchardApiClient.getMaxConcurrentJobs()`を追加し、`GET /v1/workers`の結果から総実行枠を返せるようにします。VM作成と同じCPU・メモリの既定値を利用し、HTTP失敗・不正な応答・タイムアウトを呼び出し元へ返します。

返り値は総実行枠です。実行中jobの差し引きと並列実行ループへの接続は後続PRで行います。

検証:

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test test integration_test`
- VM作成と容量計算の設定一致を、`ORCHARD_VM_CPU=3`・`ORCHARD_VM_MEMORY_GB=5`でも検証
- 差分全体のレビューと`git diff --cached --check`
