### PR TITLE
feat(cli): collect workspace package directories

### DIFF
--- a/apps/genuineci_cli/lib/src/commands/sync/read_workspace_directories.dart
+++ b/apps/genuineci_cli/lib/src/commands/sync/read_workspace_directories.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _excludedDirectories = {'build', 'coverage', 'node_modules', 'Pods'};
+
+/// Collects workspace packages and their immediate, visible subdirectories.
+///
+/// Build outputs, dependencies, hidden directories and symlinks are excluded.
+Future<List<String>> readWorkspaceDirectories(
+  Directory root,
+  Iterable<String> packagePaths,
+) async {
+  final paths = <String>[];
+  for (final packagePath in packagePaths) {
+    paths.add(packagePath);
+    final directory = Directory(p.join(root.path, packagePath));
+    await for (final entry in directory.list(followLinks: false)) {
+      if (entry is! Directory) continue;
+      final name = p.basename(entry.path);
+      if (name.startsWith('.') || _excludedDirectories.contains(name)) continue;
+      paths.add(p.posix.join(packagePath.replaceAll(r'\', '/'), name));
+    }
+  }
+  return paths;
+}

--- a/apps/genuineci_cli/test/src/commands/sync/read_workspace_directories_test.dart
+++ b/apps/genuineci_cli/test/src/commands/sync/read_workspace_directories_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:genuineci_cli/src/commands/sync/read_workspace_directories.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory root;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('genuineci-directories-');
+  });
+
+  tearDown(() => root.delete(recursive: true));
+
+  Future<Directory> addDirectory(String path) =>
+      Directory(p.join(root.path, path)).create(recursive: true);
+
+  test('includes package roots and only immediate subdirectories', () async {
+    await addDirectory('apps/dashboard/lib/src');
+    await addDirectory('apps/dashboard/assets');
+    await addDirectory('packages/core/test');
+    await addDirectory('packages/empty');
+    await File(
+      p.join(root.path, 'apps/dashboard/pubspec.yaml'),
+    ).writeAsString('name: dashboard\n');
+
+    expect(
+      await readWorkspaceDirectories(root, [
+        'apps/dashboard',
+        'packages/core',
+        'packages/empty',
+      ]),
+      unorderedEquals([
+        'apps/dashboard',
+        'apps/dashboard/lib',
+        'apps/dashboard/assets',
+        'packages/core',
+        'packages/core/test',
+        'packages/empty',
+      ]),
+    );
+  });
+
+  test('excludes hidden directories, build outputs and dependencies', () async {
+    for (final name in [
+      'lib',
+      '.dart_tool',
+      '.git',
+      '.vscode',
+      'build',
+      'coverage',
+      'node_modules',
+      'Pods',
+    ]) {
+      await addDirectory('apps/dashboard/$name');
+    }
+
+    expect(
+      await readWorkspaceDirectories(root, ['apps/dashboard']),
+      unorderedEquals(['apps/dashboard', 'apps/dashboard/lib']),
+    );
+  });
+
+  test(
+    'excludes symbolic links to directories',
+    () async {
+      await addDirectory('apps/dashboard/lib');
+      await Link(p.join(root.path, 'apps/dashboard/linked')).create('lib');
+
+      expect(
+        await readWorkspaceDirectories(root, ['apps/dashboard']),
+        unorderedEquals(['apps/dashboard', 'apps/dashboard/lib']),
+      );
+    },
+    skip: Platform.isWindows
+        ? 'Creating symbolic links requires privileges on Windows.'
+        : false,
+  );
+}


### PR DESCRIPTION
Workspace path generation needs package subdirectories such as `apps/dashboard/lib`. Add `readWorkspaceDirectories` to collect package roots and their immediate subdirectories, excluding files, hidden directories, `build`, `coverage`, `node_modules`, `Pods`, and symbolic links. Connecting this helper to `sync paths` will follow in a separate change.

Tests cover multiple packages, packages without subdirectories, the non-recursive scan, excluded directories, and symbolic links.

Validation:

- `dart format` on both new files: no changes needed.
- `dart analyze lib`, `dart analyze test`, and `dart analyze bin`: no issues.
- `flutter test --coverage --no-pub --reporter expanded`: all 334 tests passed.
- `git diff --cached --check`: passed; full diff reviewed.
