### PR TITLE
feat(cli): generate workspace subdirectory paths

### DIFF
--- a/apps/genuineci_cli/lib/src/commands/sync/sync_paths_command.dart
+++ b/apps/genuineci_cli/lib/src/commands/sync/sync_paths_command.dart
@@ -6,6 +6,7 @@ import 'package:cli_util/cli_logging.dart';
 import '../../extensions/file_extensions.dart';
 import '../../i18n/i18n.dart';
 import 'generate_workspace_paths.dart';
+import 'read_workspace_directories.dart';
 import 'read_workspace_packages.dart';
 
 class SyncPathsCommand extends Command<int> {
@@ -34,7 +35,8 @@ class SyncPathsCommand extends Command<int> {
         return 1;
       }
       final packages = await readWorkspacePackages(root);
-      final source = generateWorkspacePaths(packages.values);
+      final paths = await readWorkspaceDirectories(root, packages.values);
+      final source = generateWorkspacePaths(paths);
       final file = File('${root.path}/genuine_ci/paths.g.dart');
       await file.writeAsStringAtomic(source);
       _logger.stdout(t.sync.paths.saved(path: file.path));

--- a/apps/genuineci_cli/test/src/commands/sync/sync_paths_command_test.dart
+++ b/apps/genuineci_cli/test/src/commands/sync/sync_paths_command_test.dart
@@ -67,8 +67,11 @@ void main() {
   test('creates paths from a nested directory without login', () async {
     await output.delete();
     final nested = await Directory(
-      p.join(root.path, 'apps/dashboard/lib'),
-    ).create();
+      p.join(root.path, 'apps/dashboard/lib/src'),
+    ).create(recursive: true);
+    for (final name in ['.dart_tool', 'build']) {
+      await Directory(p.join(root.path, 'apps/dashboard', name)).create();
+    }
     final secrets = File(p.join(workflows.path, 'secrets.g.dart'));
     await secrets.writeAsString('// Existing secrets\n');
 
@@ -79,9 +82,19 @@ void main() {
     expect(
       source,
       contains(
-        'WorkspaceDirectory get dashboard => const WorkspaceDirectory("apps/dashboard");',
+        r'WorkspaceRoot$Apps$Dashboard get dashboard => '
+        r'const WorkspaceRoot$Apps$Dashboard._("apps/dashboard");',
       ),
     );
+    expect(
+      source,
+      contains(
+        'WorkspaceDirectory get lib => const WorkspaceDirectory("apps/dashboard/lib");',
+      ),
+    );
+    for (final field in ['src', 'dartTool', 'build']) {
+      expect(source, isNot(contains('get $field')));
+    }
     expect(source, isNot(contains(root.path)));
     expect(await secrets.readAsString(), '// Existing secrets\n');
     expect(logger.stdoutMessages, [t.sync.paths.saved(path: output.path)]);
@@ -188,6 +201,18 @@ void main() {
       );
     },
   );
+
+  test('preserves paths when a package subdirectory name is invalid', () async {
+    await Directory(p.join(root.path, 'apps/dashboard/class')).create();
+
+    expect(await runSync(), 1);
+
+    await expectPreserved();
+    expect(
+      logger.stderrMessages.single,
+      contains('Directory "class" cannot be used as a Dart field'),
+    );
+  });
 
   test('uses directory names even when the package name differs', () async {
     await File(

--- a/genuine_ci/paths.g.dart
+++ b/genuine_ci/paths.g.dart
@@ -16,16 +16,76 @@ extension type const WorkspaceRoot._(String _path) implements WorkspaceDirectory
 }
 
 extension type const WorkspaceRoot$Apps._(String _path) implements WorkspaceDirectory {
-  WorkspaceDirectory get buildJobPlanner => const WorkspaceDirectory("apps/build_job_planner");
-  WorkspaceDirectory get buildJobWorker => const WorkspaceDirectory("apps/build_job_worker");
-  WorkspaceDirectory get dashboard => const WorkspaceDirectory("apps/dashboard");
-  WorkspaceDirectory get genuineciCli => const WorkspaceDirectory("apps/genuineci_cli");
-  WorkspaceDirectory get openciServer => const WorkspaceDirectory("apps/openci_server");
+  WorkspaceRoot$Apps$BuildJobPlanner get buildJobPlanner => const WorkspaceRoot$Apps$BuildJobPlanner._("apps/build_job_planner");
+  WorkspaceRoot$Apps$BuildJobWorker get buildJobWorker => const WorkspaceRoot$Apps$BuildJobWorker._("apps/build_job_worker");
+  WorkspaceRoot$Apps$Dashboard get dashboard => const WorkspaceRoot$Apps$Dashboard._("apps/dashboard");
+  WorkspaceRoot$Apps$GenuineciCli get genuineciCli => const WorkspaceRoot$Apps$GenuineciCli._("apps/genuineci_cli");
+  WorkspaceRoot$Apps$OpenciServer get openciServer => const WorkspaceRoot$Apps$OpenciServer._("apps/openci_server");
+}
+
+extension type const WorkspaceRoot$Apps$BuildJobPlanner._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get bin => const WorkspaceDirectory("apps/build_job_planner/bin");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/build_job_planner/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("apps/build_job_planner/test");
+}
+
+extension type const WorkspaceRoot$Apps$BuildJobWorker._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get bin => const WorkspaceDirectory("apps/build_job_worker/bin");
+  WorkspaceDirectory get integrationTest => const WorkspaceDirectory("apps/build_job_worker/integration_test");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/build_job_worker/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("apps/build_job_worker/test");
+}
+
+extension type const WorkspaceRoot$Apps$Dashboard._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get android => const WorkspaceDirectory("apps/dashboard/android");
+  WorkspaceDirectory get assets => const WorkspaceDirectory("apps/dashboard/assets");
+  WorkspaceDirectory get ios => const WorkspaceDirectory("apps/dashboard/ios");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/dashboard/lib");
+  WorkspaceDirectory get macos => const WorkspaceDirectory("apps/dashboard/macos");
+  WorkspaceDirectory get scripts => const WorkspaceDirectory("apps/dashboard/scripts");
+  WorkspaceDirectory get test => const WorkspaceDirectory("apps/dashboard/test");
+  WorkspaceDirectory get web => const WorkspaceDirectory("apps/dashboard/web");
+}
+
+extension type const WorkspaceRoot$Apps$GenuineciCli._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get bin => const WorkspaceDirectory("apps/genuineci_cli/bin");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/genuineci_cli/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("apps/genuineci_cli/test");
+}
+
+extension type const WorkspaceRoot$Apps$OpenciServer._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get integrationTest => const WorkspaceDirectory("apps/openci_server/integration_test");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/openci_server/lib");
+  WorkspaceDirectory get routes => const WorkspaceDirectory("apps/openci_server/routes");
+  WorkspaceDirectory get test => const WorkspaceDirectory("apps/openci_server/test");
 }
 
 extension type const WorkspaceRoot$Packages._(String _path) implements WorkspaceDirectory {
-  WorkspaceDirectory get genuineCi => const WorkspaceDirectory("packages/genuine_ci");
-  WorkspaceDirectory get macosUpdater => const WorkspaceDirectory("packages/macos_updater");
-  WorkspaceDirectory get openciShared => const WorkspaceDirectory("packages/openci_shared");
-  WorkspaceDirectory get pubspecVersionHook => const WorkspaceDirectory("packages/pubspec_version_hook");
+  WorkspaceRoot$Packages$GenuineCi get genuineCi => const WorkspaceRoot$Packages$GenuineCi._("packages/genuine_ci");
+  WorkspaceRoot$Packages$MacosUpdater get macosUpdater => const WorkspaceRoot$Packages$MacosUpdater._("packages/macos_updater");
+  WorkspaceRoot$Packages$OpenciShared get openciShared => const WorkspaceRoot$Packages$OpenciShared._("packages/openci_shared");
+  WorkspaceRoot$Packages$PubspecVersionHook get pubspecVersionHook => const WorkspaceRoot$Packages$PubspecVersionHook._("packages/pubspec_version_hook");
+}
+
+extension type const WorkspaceRoot$Packages$GenuineCi._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get lib => const WorkspaceDirectory("packages/genuine_ci/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("packages/genuine_ci/test");
+}
+
+extension type const WorkspaceRoot$Packages$MacosUpdater._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get example => const WorkspaceDirectory("packages/macos_updater/example");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("packages/macos_updater/lib");
+  WorkspaceDirectory get macos => const WorkspaceDirectory("packages/macos_updater/macos");
+  WorkspaceDirectory get pigeons => const WorkspaceDirectory("packages/macos_updater/pigeons");
+  WorkspaceDirectory get test => const WorkspaceDirectory("packages/macos_updater/test");
+}
+
+extension type const WorkspaceRoot$Packages$OpenciShared._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get lib => const WorkspaceDirectory("packages/openci_shared/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("packages/openci_shared/test");
+}
+
+extension type const WorkspaceRoot$Packages$PubspecVersionHook._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get lib => const WorkspaceDirectory("packages/pubspec_version_hook/lib");
+  WorkspaceDirectory get test => const WorkspaceDirectory("packages/pubspec_version_hook/test");
 }


### PR DESCRIPTION
`genuineci sync paths` currently generates accessors only down to each workspace package. Connect `readWorkspaceDirectories` so it also generates typed accessors for immediate package subdirectories, including `WorkspacePaths.root.apps.dashboard.lib`, and regenerate `genuine_ci/paths.g.dart`.

Command tests verify that only immediate, eligible subdirectories are generated and that an invalid child directory name preserves the existing output file.

Validation:

- `dart format --output=none --set-exit-if-changed` on all three changed files: passed.
- `dart analyze lib`, `dart analyze test`, and `dart analyze bin` in `apps/genuineci_cli`: no issues.
- `dart analyze genuine_ci`: no issues.
- `flutter test --coverage --no-pub --reporter expanded` in `apps/genuineci_cli`: all 335 tests passed.
- `dart run apps/genuineci_cli/bin/genuineci_cli.dart sync paths`: successfully regenerated the workspace paths.
- `git diff --cached --check`: passed; full diff reviewed.
