### PR TITLE
refactor(ci): use typed directories for Base64 files

### DIFF
--- a/genuine_ci/dashboard_ci.dart
+++ b/genuine_ci/dashboard_ci.dart
@@ -10,7 +10,8 @@ Future<void> main() async {
   );
 
   await genuineCI.placeFileFromBase64(
-    path: 'apps/dashboard/lib/firebase_options.dart',
+    dir: WorkspacePaths.root.apps.dashboard.lib,
+    fileName: 'firebase_options.dart',
     base64Content: Secrets.firebaseOptionsDartBase64,
   );
 

--- a/packages/genuine_ci/lib/src/genuine_ci.dart
+++ b/packages/genuine_ci/lib/src/genuine_ci.dart
@@ -6,6 +6,7 @@ import 'package:meta/meta.dart';
 import 'ci_trigger.dart';
 import 'command_runner.dart';
 import 'machine_type.dart';
+import 'workspace_directory.dart';
 
 class GenuineCI {
   GenuineCI._({
@@ -59,7 +60,8 @@ class GenuineCI {
   }
 
   Future<void> placeFileFromBase64({
-    required String path,
+    required WorkspaceDirectory dir,
+    required String fileName,
     required String base64Content,
   }) async {
     final List<int> bytes;
@@ -68,7 +70,9 @@ class GenuineCI {
     } on FormatException {
       throw const FormatException('Invalid Base64 content.');
     }
-    final file = File(resolveWorkingDirectory(path));
+    final file = File(
+      '${resolveWorkingDirectory(dir)}${Platform.pathSeparator}$fileName',
+    );
     await file.parent.create(recursive: true);
     await file.writeAsBytes(bytes, flush: true);
   }

--- a/packages/genuine_ci/test/src/genuine_ci_test.dart
+++ b/packages/genuine_ci/test/src/genuine_ci_test.dart
@@ -47,7 +47,8 @@ void main() {
         const content = '// Firebase設定\nconst projectId = "test-project";\n';
 
         await ci.placeFileFromBase64(
-          path: 'apps/dashboard/lib/firebase_options.dart',
+          dir: const WorkspaceDirectory('apps/dashboard/lib'),
+          fileName: 'firebase_options.dart',
           base64Content: base64Encode(utf8.encode(content)),
         );
 
@@ -68,7 +69,8 @@ void main() {
       final bytes = List<int>.generate(256, (index) => index);
 
       await ci.placeFileFromBase64(
-        path: 'signing/certificate.p12',
+        dir: const WorkspaceDirectory('signing'),
+        fileName: 'certificate.p12',
         base64Content: base64Encode(bytes),
       );
 
@@ -87,7 +89,8 @@ void main() {
         );
 
         await ci.placeFileFromBase64(
-          path: 'config.txt',
+          dir: const WorkspaceDirectory('.'),
+          fileName: 'config.txt',
           base64Content: base64Encode(utf8.encode('new')),
         );
 
@@ -96,7 +99,11 @@ void main() {
     );
 
     test('accepts empty Base64 as an empty file', () async {
-      await ci.placeFileFromBase64(path: 'empty.txt', base64Content: '');
+      await ci.placeFileFromBase64(
+        dir: const WorkspaceDirectory('.'),
+        fileName: 'empty.txt',
+        base64Content: '',
+      );
 
       expect(await File('${workspace.path}/empty.txt').readAsBytes(), isEmpty);
     });
@@ -113,7 +120,8 @@ void main() {
 
           await expectLater(
             ci.placeFileFromBase64(
-              path: 'config/private.txt',
+              dir: const WorkspaceDirectory('config'),
+              fileName: 'private.txt',
               base64Content: 'private-base64-content!!!',
             ),
             throwsA(
@@ -147,7 +155,8 @@ void main() {
 
       await expectLater(
         ci.placeFileFromBase64(
-          path: 'blocked/config.txt',
+          dir: const WorkspaceDirectory('blocked'),
+          fileName: 'config.txt',
           base64Content: base64Encode(utf8.encode('new')),
         ),
         throwsA(isA<FileSystemException>()),


### PR DESCRIPTION
`placeFileFromBase64` accepted a full path as a plain string, so callers could not use the generated directory type to catch directory argument mistakes. Replace `path` with a required `WorkspaceDirectory dir` and `String fileName`, and resolve the destination relative to the workspace root. Update Dashboard CI to use `WorkspacePaths.root.apps.dashboard.lib` and migrate the existing file-restoration tests to the new API.

Validation:

- `dart format` on all three changed files: no changes needed.
- `dart analyze packages/genuine_ci` and `dart analyze genuine_ci`: no issues.
- `dart test --reporter expanded` in `packages/genuine_ci`: all 26 tests passed.
- A temporary compiler probe confirmed that passing a plain `String` to `dir` produces a type error.
- `git diff --cached --check`: passed; full diff reviewed.
