### PR TITLE
feat(ci)!: support multiple workflow triggers

### DIFF
--- a/apps/build_job_planner/lib/src/genuine_ci_parser.dart
+++ b/apps/build_job_planner/lib/src/genuine_ci_parser.dart
@@ -32,7 +32,7 @@ class ParsedCiTrigger {
     final expectedEventType = switch (type) {
       'push' => 'push',
       'pullRequest' => 'pull_request',
-      _ => type,
+      _ => null,
     };
 
     if (eventType != expectedEventType) {

--- a/apps/build_job_planner/lib/src/genuine_ci_parser.dart
+++ b/apps/build_job_planner/lib/src/genuine_ci_parser.dart
@@ -6,30 +6,40 @@ class ParsedWorkflow {
   const ParsedWorkflow({
     required this.workflowFileName,
     required this.workflowName,
-    required this.triggerType,
-    required this.triggerBranch,
+    required this.ciTriggers,
   });
 
   final String workflowFileName;
   final String workflowName;
-  final String triggerType; // 'push' or 'pullRequest'
-  final String triggerBranch;
+  final List<ParsedCiTrigger> ciTriggers;
+
+  bool matches({required String eventType, required String branch}) =>
+      ciTriggers.any(
+        (trigger) => trigger.matches(eventType: eventType, branch: branch),
+      );
+}
+
+class ParsedCiTrigger {
+  const ParsedCiTrigger({required this.type, required this.branch});
+
+  final String type; // 'push' or 'pullRequest'
+  final String branch;
 
   bool matches({
     required String eventType, // 'push' or 'pull_request'
     required String branch,
   }) {
-    final expectedEventType = switch (triggerType) {
+    final expectedEventType = switch (type) {
       'push' => 'push',
       'pullRequest' => 'pull_request',
-      _ => triggerType,
+      _ => type,
     };
 
     if (eventType != expectedEventType) {
       return false;
     }
 
-    return _matchesBranch(triggerBranch, branch);
+    return _matchesBranch(this.branch, branch);
   }
 
   static bool _matchesBranch(String pattern, String branch) {
@@ -73,7 +83,7 @@ class _GenuineCiInitVisitor extends RecursiveAstVisitor<void> {
     final methodName = node.methodName.name;
 
     if (target is SimpleIdentifier &&
-        (target.name == 'GenuineCI' || target.name == 'GenuineCi') &&
+        target.name == 'GenuineCI' &&
         methodName == 'init') {
       _extractFromInitArgs(node.argumentList);
     }
@@ -81,8 +91,7 @@ class _GenuineCiInitVisitor extends RecursiveAstVisitor<void> {
 
   void _extractFromInitArgs(ArgumentList argumentList) {
     String? workflowName;
-    String? triggerType;
-    String? triggerBranch;
+    List<ParsedCiTrigger>? ciTriggers;
 
     for (final argument in argumentList.arguments) {
       if (argument is NamedExpression) {
@@ -91,31 +100,74 @@ class _GenuineCiInitVisitor extends RecursiveAstVisitor<void> {
 
         if (paramName == 'workflowName') {
           workflowName = _extractStringValue(expression);
-        } else if (paramName == 'ciTrigger') {
-          if (expression is MethodInvocation) {
-            final methodName = expression.methodName.name;
-            if (methodName == 'push' || methodName == 'pullRequest') {
-              triggerType = methodName;
-              for (final triggerArg in expression.argumentList.arguments) {
-                if (triggerArg is NamedExpression &&
-                    triggerArg.name.label.name == 'branch') {
-                  triggerBranch = _extractStringValue(triggerArg.expression);
-                }
-              }
-            }
-          }
+        } else if (paramName == 'ciTriggers') {
+          ciTriggers = _extractTriggers(expression);
         }
       }
     }
 
-    if (workflowName != null && triggerType != null && triggerBranch != null) {
+    if (workflowName != null && ciTriggers != null) {
       workflow = ParsedWorkflow(
         workflowFileName: fileName,
         workflowName: workflowName,
-        triggerType: triggerType,
-        triggerBranch: triggerBranch,
+        ciTriggers: ciTriggers,
       );
     }
+  }
+
+  List<ParsedCiTrigger>? _extractTriggers(Expression expression) {
+    if (expression is! ListLiteral) return null;
+
+    final triggers = <ParsedCiTrigger>[];
+    for (final element in expression.elements) {
+      if (element is! Expression) return null;
+      final trigger = _extractTrigger(element);
+      if (trigger == null) return null;
+      triggers.add(trigger);
+    }
+    return triggers;
+  }
+
+  ParsedCiTrigger? _extractTrigger(Expression expression) {
+    String? className;
+    String? triggerType;
+    ArgumentList? argumentList;
+
+    if (expression is MethodInvocation) {
+      final target = expression.target;
+      if (target is SimpleIdentifier) {
+        className = target.name;
+        triggerType = expression.methodName.name;
+        argumentList = expression.argumentList;
+      }
+    } else if (expression is InstanceCreationExpression) {
+      final constructor = expression.constructorName;
+      if (constructor.name != null) {
+        className = constructor.type.name.lexeme;
+        triggerType = constructor.name!.name;
+      } else {
+        // Before resolution, `const CiTrigger.push(...)` is a prefixed type.
+        className = constructor.type.importPrefix?.name.lexeme;
+        triggerType = constructor.type.name.lexeme;
+      }
+      argumentList = expression.argumentList;
+    }
+
+    if (className != 'CiTrigger' ||
+        (triggerType != 'push' && triggerType != 'pullRequest') ||
+        argumentList == null) {
+      return null;
+    }
+
+    for (final argument in argumentList.arguments) {
+      if (argument is NamedExpression && argument.name.label.name == 'branch') {
+        final branch = _extractStringValue(argument.expression);
+        if (branch != null) {
+          return ParsedCiTrigger(type: triggerType!, branch: branch);
+        }
+      }
+    }
+    return null;
   }
 
   String? _extractStringValue(Expression expression) {

--- a/apps/build_job_planner/test/genuine_ci_parser_test.dart
+++ b/apps/build_job_planner/test/genuine_ci_parser_test.dart
@@ -5,12 +5,20 @@ void main() {
   group('parseGenuineCiWorkflow', () {
     for (final args in [
       "workflowName: 'CI'",
-      "ciTrigger: CiTrigger.push(branch: 'main')",
-      "workflowName: 'CI', ciTrigger: CiTrigger.push()",
-      "workflowName: 'CI', ciTrigger: CiTrigger.unknown(branch: 'main')",
-      "workflowName: name, ciTrigger: CiTrigger.push(branch: 'main')",
-      r"workflowName: 'CI $name', ciTrigger: CiTrigger.push(branch: 'main')",
-      r"workflowName: 'CI', ciTrigger: CiTrigger.push(branch: 'release/$version')",
+      "ciTriggers: [CiTrigger.push(branch: 'main')]",
+      "workflowName: 'CI', ciTriggers: [CiTrigger.push()]",
+      "workflowName: 'CI', ciTriggers: [CiTrigger.unknown(branch: 'main')]",
+      "workflowName: 'CI', ciTriggers: [SomethingElse.push(branch: 'main')]",
+      "workflowName: 'CI', ciTriggers: [const SomethingElse.push(branch: 'main')]",
+      "workflowName: 'CI', ciTriggers: CiTrigger.push(branch: 'main')",
+      "workflowName: 'CI', ciTriggers: triggers",
+      "workflowName: 'CI', ciTriggers: [CiTrigger.push(branch: 'main'), trigger]",
+      "workflowName: 'CI', ciTriggers: [CiTrigger.push(branch: 'main'), ...triggers]",
+      "workflowName: 'CI', ciTriggers: [if (enabled) CiTrigger.push(branch: 'main')]",
+      "workflowName: 'CI', ciTriggers: [CiTrigger.push(branch: 'main'), CiTrigger.pullRequest()]",
+      "workflowName: name, ciTriggers: [CiTrigger.push(branch: 'main')]",
+      r"workflowName: 'CI $name', ciTriggers: [CiTrigger.push(branch: 'main')]",
+      r"workflowName: 'CI', ciTriggers: [CiTrigger.push(branch: 'release/$version')]",
     ]) {
       test('does not schedule an incomplete or dynamic definition: $args', () {
         final workflow = parseGenuineCiWorkflow(
@@ -24,9 +32,9 @@ void main() {
 
     test('ignores unrelated init calls and workflow text in comments', () {
       final workflow = parseGenuineCiWorkflow('''
-        // GenuineCI.init(workflowName: 'Comment', ciTrigger: CiTrigger.push(branch: '*'));
+        // GenuineCI.init(workflowName: 'Comment', ciTriggers: [CiTrigger.push(branch: '*')]);
         void main() {
-          SomethingElse.init(workflowName: 'Other', ciTrigger: CiTrigger.push(branch: '*'));
+          SomethingElse.init(workflowName: 'Other', ciTriggers: [CiTrigger.push(branch: '*')]);
         }
       ''', 'ci.dart');
 
@@ -40,7 +48,7 @@ import 'package:genuine_ci/genuine_ci.dart';
 Future<void> main() async {
   final genuineCI = await GenuineCI.init(
     workflowName: 'Unit Tests',
-    ciTrigger: CiTrigger.push(branch: 'main'),
+    ciTriggers: [CiTrigger.push(branch: 'main')],
   );
 
   await FlutterCi.unitTest(genuineCI.workspacePath);
@@ -52,8 +60,8 @@ Future<void> main() async {
       expect(workflow, isNotNull);
       expect(workflow!.workflowName, equals('Unit Tests'));
       expect(workflow.workflowFileName, equals('unit_test.dart'));
-      expect(workflow.triggerType, equals('push'));
-      expect(workflow.triggerBranch, equals('main'));
+      expect(workflow.ciTriggers.single.type, equals('push'));
+      expect(workflow.ciTriggers.single.branch, equals('main'));
     });
 
     test('successfully parses GenuineCI.init with pullRequest trigger', () {
@@ -61,9 +69,9 @@ Future<void> main() async {
 import 'package:genuine_ci/genuine_ci.dart';
 
 Future<void> main() async {
-  final genuineCI = await GenuineCi.init(
+  final genuineCI = await GenuineCI.init(
     workflowName: 'PR Check',
-    ciTrigger: CiTrigger.pullRequest(branch: 'feature/*'),
+    ciTriggers: [CiTrigger.pullRequest(branch: 'feature/*')],
   );
 }
 ''';
@@ -73,8 +81,85 @@ Future<void> main() async {
       expect(workflow, isNotNull);
       expect(workflow!.workflowName, equals('PR Check'));
       expect(workflow.workflowFileName, equals('pr_check.dart'));
-      expect(workflow.triggerType, equals('pullRequest'));
-      expect(workflow.triggerBranch, equals('feature/*'));
+      expect(workflow.ciTriggers.single.type, equals('pullRequest'));
+      expect(workflow.ciTriggers.single.branch, equals('feature/*'));
+    });
+
+    test('matches both pull requests and pushes with multiple triggers', () {
+      final workflow = parseGenuineCiWorkflow('''
+Future<void> main() async {
+  await GenuineCI.init(
+    workflowName: 'Dashboard CI',
+    ciTriggers: [
+      CiTrigger.pullRequest(branch: 'develop'),
+      CiTrigger.push(branch: 'develop'),
+    ],
+  );
+}
+''', 'dashboard_ci.dart');
+
+      expect(workflow, isNotNull);
+      expect(workflow!.ciTriggers, hasLength(2));
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'develop'),
+        isTrue,
+      );
+      expect(workflow.matches(eventType: 'push', branch: 'develop'), isTrue);
+      expect(workflow.matches(eventType: 'push', branch: 'main'), isFalse);
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'main'),
+        isFalse,
+      );
+    });
+
+    for (final triggers in [
+      "const [CiTrigger.push(branch: 'main')]",
+      "[const CiTrigger.push(branch: 'main')]",
+      "<CiTrigger>[CiTrigger.push(branch: 'main')]",
+    ]) {
+      test('parses constant and typed triggers: $triggers', () {
+        final workflow = parseGenuineCiWorkflow('''
+void main() {
+  GenuineCI.init(workflowName: 'CI', ciTriggers: $triggers);
+}
+''', 'ci.dart');
+
+        expect(workflow, isNotNull);
+        expect(workflow!.matches(eventType: 'push', branch: 'main'), isTrue);
+        expect(workflow.matches(eventType: 'push', branch: 'develop'), isFalse);
+      });
+    }
+
+    for (final invocation in [
+      "GenuineCI.init(workflowName: 'CI', ciTrigger: CiTrigger.push(branch: 'main'))",
+      "GenuineCi.init(workflowName: 'CI', ciTriggers: [CiTrigger.push(branch: 'main')])",
+      "GenuineCI.init(workflowName: 'CI', ciTriggers: [CITrigger.push(branch: 'main')])",
+      "GenuineCI.init(workflowName: 'CI', ciTriggers: [const CITrigger.push(branch: 'main')])",
+    ]) {
+      test('does not schedule legacy syntax: $invocation', () {
+        final workflow = parseGenuineCiWorkflow(
+          'void main() { $invocation; }',
+          'ci.dart',
+        );
+
+        expect(workflow, isNull);
+      });
+    }
+
+    test('an empty trigger list never matches an event', () {
+      final workflow = parseGenuineCiWorkflow('''
+void main() {
+  GenuineCI.init(workflowName: 'CI', ciTriggers: []);
+}
+''', 'ci.dart');
+
+      expect(workflow, isNotNull);
+      expect(workflow!.ciTriggers, isEmpty);
+      expect(workflow.matches(eventType: 'push', branch: 'main'), isFalse);
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'main'),
+        isFalse,
+      );
     });
   });
 
@@ -83,8 +168,9 @@ Future<void> main() async {
       const workflow = ParsedWorkflow(
         workflowFileName: 'ci.dart',
         workflowName: 'Release',
-        triggerType: 'push',
-        triggerBranch: 'release/v1.2+hotfix/*',
+        ciTriggers: [
+          ParsedCiTrigger(type: 'push', branch: 'release/v1.2+hotfix/*'),
+        ],
       );
 
       expect(
@@ -114,15 +200,13 @@ Future<void> main() async {
     const pushWorkflow = ParsedWorkflow(
       workflowFileName: 'deploy.dart',
       workflowName: 'Deploy',
-      triggerType: 'push',
-      triggerBranch: 'main',
+      ciTriggers: [ParsedCiTrigger(type: 'push', branch: 'main')],
     );
 
     const prWorkflow = ParsedWorkflow(
       workflowFileName: 'pr.dart',
       workflowName: 'PR Check',
-      triggerType: 'pullRequest',
-      triggerBranch: 'feature/*',
+      ciTriggers: [ParsedCiTrigger(type: 'pullRequest', branch: 'feature/*')],
     );
 
     test('matches exact branch and event', () {
@@ -146,6 +230,29 @@ Future<void> main() async {
         prWorkflow.matches(eventType: 'pull_request', branch: 'bugfix/123'),
         isFalse,
       );
+    });
+
+    test('keeps each event paired with its own branch pattern', () {
+      const workflow = ParsedWorkflow(
+        workflowFileName: 'ci.dart',
+        workflowName: 'CI',
+        ciTriggers: [
+          ParsedCiTrigger(type: 'pullRequest', branch: 'develop'),
+          ParsedCiTrigger(type: 'push', branch: 'release/*'),
+        ],
+      );
+
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'develop'),
+        isTrue,
+      );
+      expect(workflow.matches(eventType: 'push', branch: 'release/v1'), isTrue);
+      expect(workflow.matches(eventType: 'push', branch: 'develop'), isFalse);
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'release/v1'),
+        isFalse,
+      );
+      expect(workflow.matches(eventType: 'issues', branch: 'develop'), isFalse);
     });
   });
 }

--- a/apps/build_job_planner/test/genuine_ci_parser_test.dart
+++ b/apps/build_job_planner/test/genuine_ci_parser_test.dart
@@ -146,6 +146,36 @@ void main() {
       });
     }
 
+    test('parses constant trigger constructors with an import prefix', () {
+      final workflow = parseGenuineCiWorkflow('''
+import 'package:genuine_ci/genuine_ci.dart' show GenuineCI;
+import 'package:genuine_ci/genuine_ci.dart' as ci;
+
+Future<void> main() async {
+  await GenuineCI.init(
+    workflowName: 'CI',
+    ciTriggers: [
+      const ci.CiTrigger.pullRequest(branch: 'develop'),
+      const ci.CiTrigger.push(branch: 'release/*'),
+    ],
+  );
+}
+''', 'ci.dart');
+
+      expect(workflow, isNotNull);
+      expect(workflow!.ciTriggers, hasLength(2));
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'develop'),
+        isTrue,
+      );
+      expect(workflow.matches(eventType: 'push', branch: 'release/v1'), isTrue);
+      expect(workflow.matches(eventType: 'push', branch: 'develop'), isFalse);
+      expect(
+        workflow.matches(eventType: 'pull_request', branch: 'release/v1'),
+        isFalse,
+      );
+    });
+
     test('an empty trigger list never matches an event', () {
       final workflow = parseGenuineCiWorkflow('''
 void main() {
@@ -164,6 +194,21 @@ void main() {
   });
 
   group('ParsedWorkflow.matches', () {
+    for (final triggerType in ['workflow_dispatch', 'pull_request']) {
+      test('does not match unsupported trigger types: $triggerType', () {
+        final workflow = ParsedWorkflow(
+          workflowFileName: 'ci.dart',
+          workflowName: 'CI',
+          ciTriggers: [ParsedCiTrigger(type: triggerType, branch: '*')],
+        );
+
+        expect(
+          workflow.matches(eventType: triggerType, branch: 'main'),
+          isFalse,
+        );
+      });
+    }
+
     test('treats regex punctuation in branch patterns literally', () {
       const workflow = ParsedWorkflow(
         workflowFileName: 'ci.dart',

--- a/apps/build_job_planner/test/handle_webhook_task_test.dart
+++ b/apps/build_job_planner/test/handle_webhook_task_test.dart
@@ -232,7 +232,7 @@ const _workflowSource = '''
 Future<void> main() async {
   await GenuineCI.init(
     workflowName: 'CI',
-    ciTrigger: CiTrigger.push(branch: 'main'),
+    ciTriggers: [CiTrigger.push(branch: 'main')],
   );
 }
 ''';

--- a/apps/build_job_planner/test/plan_webhook_task_test.dart
+++ b/apps/build_job_planner/test/plan_webhook_task_test.dart
@@ -71,6 +71,65 @@ void main() {
       });
     });
 
+    for (final eventType in ['push', 'pull_request']) {
+      for (final branch in ['develop', 'main']) {
+        test(
+          'matches multiple triggers for $eventType targeting $branch',
+          () async {
+            _stubWorkflow(api, team, _multiTriggerWorkflowSource);
+            final task = eventType == 'push'
+                ? _pushTask(branch: branch)
+                : _pullRequestTask(
+                    baseBranch: branch,
+                    headBranch: branch == 'develop' ? 'feature/ci' : 'develop',
+                  );
+
+            final plans = await planWebhookTask(task: task, api: api);
+
+            expect(plans, hasLength(branch == 'develop' ? 1 : 0));
+            if (plans.isNotEmpty) {
+              expect(plans.single.workflowName, 'Dashboard CI');
+              expect(plans.single.workflowFileName, 'dashboard_ci.dart');
+              expect(plans.single.commitSha, 'abc123');
+              expect(
+                plans.single.branch,
+                eventType == 'push' ? 'develop' : 'feature/ci',
+              );
+              expect(
+                plans.single.pullRequestNumber,
+                eventType == 'push' ? null : 42,
+              );
+            }
+          },
+        );
+      }
+    }
+
+    test(
+      'creates only one plan when multiple triggers match the event',
+      () async {
+        _stubWorkflow(api, team, '''
+Future<void> main() async {
+  await GenuineCI.init(
+    workflowName: 'CI',
+    ciTriggers: [
+      CiTrigger.push(branch: '*'),
+      CiTrigger.push(branch: 'develop'),
+      CiTrigger.push(branch: 'develop'),
+    ],
+  );
+}
+''');
+
+        final plans = await planWebhookTask(
+          task: _pushTask(branch: 'develop'),
+          api: api,
+        );
+
+        expect(plans, hasLength(1));
+      },
+    );
+
     test(
       'returns no plans for a deleted branch without calling APIs',
       () async {
@@ -170,10 +229,55 @@ void main() {
   });
 }
 
-WebhookTask _pushTask({bool deleted = false}) {
+void _stubWorkflow(OpenCiApiService api, Team team, String source) {
+  when(
+    () => api.getTeamByInstallationId(998877),
+  ).thenAnswer((_) async => createMockResponse(team));
+  when(
+    () => api.fetchGenuineCiFiles(
+      'team-1',
+      'openci',
+      'abc123',
+      owner: 'openci-org',
+      installationId: 998877,
+    ),
+  ).thenAnswer(
+    (_) async => createMockResponse([
+      {
+        'name': 'dashboard_ci.dart',
+        'path': 'genuine_ci/dashboard_ci.dart',
+        'content': source,
+      },
+    ]),
+  );
+}
+
+WebhookTask _pullRequestTask({
+  required String baseBranch,
+  required String headBranch,
+}) {
+  return _task(
+    eventType: 'pull_request',
+    payload: jsonEncode({
+      'number': 42,
+      'pull_request': {
+        'head': {'sha': 'abc123', 'ref': headBranch},
+        'base': {'ref': baseBranch},
+        'title': 'feat: multiple triggers',
+      },
+      'repository': {
+        'name': 'openci',
+        'owner': {'login': 'openci-org'},
+      },
+      'installation': {'id': 998877},
+    }),
+  );
+}
+
+WebhookTask _pushTask({bool deleted = false, String branch = 'main'}) {
   return _task(
     payload: jsonEncode({
-      'ref': 'refs/heads/main',
+      'ref': 'refs/heads/$branch',
       'head_commit': {'id': 'abc123', 'message': 'feat: planner\n\ndetails'},
       'repository': {
         'name': 'openci',
@@ -185,11 +289,11 @@ WebhookTask _pushTask({bool deleted = false}) {
   );
 }
 
-WebhookTask _task({required String payload}) {
+WebhookTask _task({required String payload, String eventType = 'push'}) {
   return WebhookTask(
     id: 'task-1',
     deliveryId: 'delivery-1',
-    eventType: 'push',
+    eventType: eventType,
     payload: payload,
     status: 'processing',
     createdAt: DateTime.utc(2026),
@@ -202,7 +306,19 @@ String _workflowSource({required String branch}) =>
 Future<void> main() async {
   await GenuineCI.init(
     workflowName: 'CI',
-    ciTrigger: CiTrigger.push(branch: '$branch'),
+    ciTriggers: [CiTrigger.push(branch: '$branch')],
+  );
+}
+''';
+
+const _multiTriggerWorkflowSource = '''
+Future<void> main() async {
+  await GenuineCI.init(
+    workflowName: 'Dashboard CI',
+    ciTriggers: [
+      CiTrigger.pullRequest(branch: 'develop'),
+      CiTrigger.push(branch: 'develop'),
+    ],
   );
 }
 ''';

--- a/apps/openci_server/lib/github/github_service.dart
+++ b/apps/openci_server/lib/github/github_service.dart
@@ -465,7 +465,7 @@ import 'package:genuine_ci/genuine_ci.dart';
 Future<void> main() async {
   final genuineCI = await GenuineCI.init(
     workflowName: 'Dashboard CI',
-    ciTrigger: CiTrigger.push(branch: '*'),
+    ciTriggers: [CiTrigger.push(branch: '*')],
   );
 }
 ''',

--- a/genuine_ci/dashboard_ci.dart
+++ b/genuine_ci/dashboard_ci.dart
@@ -6,7 +6,10 @@ import 'secrets.g.dart';
 Future<void> main() async {
   final genuineCI = await GenuineCI.init(
     workflowName: 'Dashboard CI',
-    ciTrigger: CiTrigger.pullRequest(branch: 'develop'),
+    ciTriggers: [
+      CiTrigger.pullRequest(branch: 'develop'),
+      CiTrigger.push(branch: 'develop'),
+    ],
   );
 
   await genuineCI.placeFileFromBase64(

--- a/packages/genuine_ci/lib/src/ci_trigger.dart
+++ b/packages/genuine_ci/lib/src/ci_trigger.dart
@@ -12,5 +12,3 @@ abstract class CiTrigger with _$CiTrigger {
     required String branch,
   }) = _PullRequestCiTrigger;
 }
-
-typedef CITrigger = CiTrigger;

--- a/packages/genuine_ci/lib/src/genuine_ci.dart
+++ b/packages/genuine_ci/lib/src/genuine_ci.dart
@@ -11,7 +11,7 @@ import 'workspace_directory.dart';
 class GenuineCI {
   GenuineCI._({
     required this.workflowName,
-    required this.ciTrigger,
+    required this.ciTriggers,
     required this.machine,
     this.currentWorkingDirectory,
     required this.workspacePath,
@@ -22,18 +22,20 @@ class GenuineCI {
     required this.workspacePath,
     this.currentWorkingDirectory,
   }) : workflowName = 'test',
-       ciTrigger = const CiTrigger.push(branch: 'test'),
+       ciTriggers = const [CiTrigger.push(branch: 'test')],
        machine = MachineType.macOsLatest;
 
   final String workflowName;
-  final CiTrigger ciTrigger;
+
+  /// Events that can start this workflow. Any matching trigger schedules a run.
+  final List<CiTrigger> ciTriggers;
   final MachineType machine;
   final String? currentWorkingDirectory;
   final String workspacePath;
 
   static Future<GenuineCI> init({
     required String workflowName,
-    required CiTrigger ciTrigger,
+    required List<CiTrigger> ciTriggers,
     MachineType machine = MachineType.macOsLatest,
     String? currentWorkingDirectory,
     String? workspacePath,
@@ -42,7 +44,7 @@ class GenuineCI {
 
     return GenuineCI._(
       workflowName: workflowName,
-      ciTrigger: ciTrigger,
+      ciTriggers: List.unmodifiable(ciTriggers),
       machine: machine,
       currentWorkingDirectory: currentWorkingDirectory,
       workspacePath: workspace,

--- a/packages/genuine_ci/test/src/genuine_ci_test.dart
+++ b/packages/genuine_ci/test/src/genuine_ci_test.dart
@@ -167,10 +167,28 @@ void main() {
   });
 
   group('GenuineCI.init', () {
+    test('retains all configured triggers as an immutable snapshot', () async {
+      final triggers = [
+        const CiTrigger.pullRequest(branch: 'develop'),
+        const CiTrigger.push(branch: 'develop'),
+      ];
+      final ci = await GenuineCI.init(
+        workflowName: 'Dashboard CI',
+        ciTriggers: triggers,
+      );
+      triggers.clear();
+
+      expect(ci.ciTriggers, const [
+        CiTrigger.pullRequest(branch: 'develop'),
+        CiTrigger.push(branch: 'develop'),
+      ]);
+      expect(() => ci.ciTriggers.clear(), throwsUnsupportedError);
+    });
+
     test('initializes with default current directory as workspace', () async {
       final ci = await GenuineCI.init(
         workflowName: 'Test Workflow',
-        ciTrigger: const CiTrigger.push(branch: 'main'),
+        ciTriggers: const [CiTrigger.push(branch: 'main')],
       );
 
       expect(ci.workflowName, 'Test Workflow');
@@ -181,7 +199,7 @@ void main() {
       final customPath = '${Directory.systemTemp.path}/custom_workspace';
       final ci = await GenuineCI.init(
         workflowName: 'Test Workflow',
-        ciTrigger: const CiTrigger.push(branch: 'main'),
+        ciTriggers: const [CiTrigger.push(branch: 'main')],
         workspacePath: customPath,
       );
 


### PR DESCRIPTION
GenuineCI workflows could declare only one trigger. Replace `ciTrigger` with `ciTriggers` so the same workflow can run for both pull requests targeting `develop` and pushes to `develop`.

- Match any supported trigger and create at most one job per workflow for each webhook, even when multiple conditions match. Reject unsupported trigger types.
- Keep pull-request filtering on the base branch and support inline constant and typed trigger lists, including explicit constant constructors with an import prefix.
- Update the dashboard workflow and server mock workflow to use the list API.
- Remove the `CITrigger` alias and `GenuineCi` parser compatibility. Existing workflows must use `GenuineCI.init(ciTriggers: [...])` with `CiTrigger`; backward compatibility is intentionally removed.

Validation completed locally:

- `dart format --output=none --set-exit-if-changed` for all 9 changed Dart files and the planner package.
- Static analysis passed for `packages/genuine_ci`, `apps/build_job_planner`, `apps/openci_server`, and `genuine_ci`; the planner was rechecked with `flutter analyze --no-pub apps/build_job_planner` after the coverage fix.
- `flutter test --coverage --no-pub`: all 69 planner tests passed, with 100% patch coverage for the parser (37/37 executable changed lines).
- `dart test --reporter expanded`: 27 SDK tests and 540 server tests passed.
- Reviewed the full diff and passed `git diff --check`.

Live webhook execution and local PostgreSQL integration tests were not run. The server CI job runs the PostgreSQL integration suite.
