### PR TITLE
fix(server): disable internal routes by default

### DIFF
--- a/apps/genuineci_cli/README.md
+++ b/apps/genuineci_cli/README.md
@@ -9,6 +9,9 @@ it stops the old build-job-worker and waits for all running jobs to finish while
 the server remains available for saving results and deleting their VMs. It then
 rebuilds and starts the application containers.
 
+The `/internal` seed and cleanup API is disabled by default. `genuineci dev start`
+automatically enables it by passing `ENABLE_INTERNAL_API=true` to Docker Compose.
+
 To also queue the default smoke-test build job:
 
 ```sh

--- a/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
+++ b/apps/genuineci_cli/lib/src/commands/dev/start_docker_compose.dart
@@ -60,7 +60,10 @@ Future<bool> startDockerCompose(
   };
   logger.stdout('\n$message');
 
-  final composeEnvironment = environment ?? Platform.environment;
+  final composeEnvironment = {
+    ...(environment ?? Platform.environment),
+    'ENABLE_INTERNAL_API': 'true',
+  };
 
   try {
     final exitCode = await processRunner(

--- a/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
+++ b/apps/genuineci_cli/test/src/commands/dev/start_docker_compose_test.dart
@@ -64,7 +64,10 @@ void main() {
               }) async {
                 expect(executable, 'docker');
                 expect(workingDirectory, projectRoot.path);
-                expect(environment, {'PATH': '/usr/local/bin'});
+                expect(environment, {
+                  'PATH': '/usr/local/bin',
+                  'ENABLE_INTERNAL_API': 'true',
+                });
                 calls.add(args);
                 return 0;
               },
@@ -128,6 +131,7 @@ void main() {
         'BASE_VM_NAME': 'custom-base',
         'INTERNAL_API_KEY': 'custom-api-key',
         'ORCHARD_API_URL': 'https://custom-orchard.example.com',
+        'ENABLE_INTERNAL_API': 'true',
       });
       expect(logger.stderrMessages, isEmpty);
       expect(
@@ -139,13 +143,17 @@ void main() {
       );
     });
 
-    test('leaves unset configuration to Compose and its .env file', () async {
+    test('enables the API without mutating the input', () async {
       late Map<String, String> capturedEnvironment;
+      final suppliedEnvironment = {
+        'PATH': '/usr/local/bin',
+        'ENABLE_INTERNAL_API': 'false',
+      };
 
       final result = await startDockerCompose(
         logger,
         projectRoot,
-        environment: const {'PATH': '/usr/local/bin'},
+        environment: suppliedEnvironment,
         processRunner:
             (_, _, {required workingDirectory, required environment}) async {
               capturedEnvironment = environment;
@@ -154,7 +162,14 @@ void main() {
       );
 
       expect(result, isTrue);
-      expect(capturedEnvironment, {'PATH': '/usr/local/bin'});
+      expect(capturedEnvironment, {
+        'PATH': '/usr/local/bin',
+        'ENABLE_INTERNAL_API': 'true',
+      });
+      expect(suppliedEnvironment, {
+        'PATH': '/usr/local/bin',
+        'ENABLE_INTERNAL_API': 'false',
+      });
     });
 
     test(
@@ -175,12 +190,16 @@ void main() {
         expect(result, isTrue);
         expect(
           capturedEnvironment.keys,
-          unorderedEquals(Platform.environment.keys),
+          unorderedEquals({
+            ...Platform.environment.keys,
+            'ENABLE_INTERNAL_API',
+          }),
         );
+        expect(capturedEnvironment['ENABLE_INTERNAL_API'], 'true');
         expect(
-          capturedEnvironment.entries.every(
-            (entry) => entry.value == Platform.environment[entry.key],
-          ),
+          capturedEnvironment.entries
+              .where((entry) => entry.key != 'ENABLE_INTERNAL_API')
+              .every((entry) => entry.value == Platform.environment[entry.key]),
           isTrue,
         );
       },

--- a/apps/openci_server/routes/_middleware.dart
+++ b/apps/openci_server/routes/_middleware.dart
@@ -31,7 +31,23 @@ Handler middleware(Handler handler) {
       .use(authProvider(_firebaseApp))
       .use(provider<FirebaseApp>((context) => _firebaseApp))
       .use(corsMiddleware())
+      .use(internalRoutesMiddleware())
       .use(requestLogger());
+}
+
+Middleware internalRoutesMiddleware({Map<String, String>? environment}) {
+  final env = environment ?? Platform.environment;
+  final enabled = env['ENABLE_INTERNAL_API'] == 'true';
+
+  return (handler) {
+    return (context) {
+      final segments = context.request.uri.pathSegments;
+      if (!enabled && segments.isNotEmpty && segments.first == 'internal') {
+        return Response(statusCode: HttpStatus.notFound);
+      }
+      return handler(context);
+    };
+  };
 }
 
 Middleware sentryMiddleware() {

--- a/apps/openci_server/test/routes/internal_routes_middleware_test.dart
+++ b/apps/openci_server/test/routes/internal_routes_middleware_test.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_test/dart_frog_test.dart';
+import 'package:test/test.dart';
+
+import '../../routes/_middleware.dart';
+import '../../routes/internal/build_jobs.dart' as build_jobs;
+import '../../routes/internal/seed/index.dart' as seed;
+import '../../routes/internal/seed/jobs.dart' as seed_jobs;
+import '../../routes/internal/seed/teams.dart' as seed_teams;
+
+void main() {
+  group('internalRoutesMiddleware', () {
+    for (final (path, method, route) in <(String, HttpMethod, Handler)>[
+      ('/internal/build_jobs', HttpMethod.delete, build_jobs.onRequest),
+      ('/internal/seed', HttpMethod.post, seed.onRequest),
+      ('/internal/seed/teams', HttpMethod.post, seed_teams.onRequest),
+      ('/internal/seed/jobs', HttpMethod.post, seed_jobs.onRequest),
+      ('/internal/seed/jobs', HttpMethod.delete, seed_jobs.onRequest),
+    ]) {
+      test(
+        'blocks ${method.name} $path before accessing the database',
+        () async {
+          final context = TestRequestContext(path: path, method: method);
+          final handler = internalRoutesMiddleware(environment: const {})(
+            route,
+          );
+
+          final response = await handler(context.context);
+
+          expect(response.statusCode, HttpStatus.notFound);
+        },
+      );
+    }
+
+    for (final value in [null, '', 'false', 'TRUE', '1', ' true ', 'invalid']) {
+      test(
+        'disables internal routes when ENABLE_INTERNAL_API is $value',
+        () async {
+          final context = TestRequestContext(path: '/internal/seed');
+          final handler = internalRoutesMiddleware(
+            environment: {'ENABLE_INTERNAL_API': ?value},
+          )((_) => throw StateError('Disabled route must not run'));
+
+          final response = await handler(context.context);
+
+          expect(response.statusCode, HttpStatus.notFound);
+          expect(await response.body(), isEmpty);
+        },
+      );
+    }
+
+    for (final method in HttpMethod.values) {
+      test('blocks ${method.name} even with an internal API key', () async {
+        final context = TestRequestContext(
+          path: '/internal/seed/jobs',
+          method: method,
+          headers: {'Authorization': 'Bearer test-internal-key'},
+        );
+        final handler = internalRoutesMiddleware(
+          environment: const {'INTERNAL_API_KEY': 'test-internal-key'},
+        )((_) => throw StateError('Disabled route must not run'));
+
+        final response = await handler(context.context);
+
+        expect(response.statusCode, HttpStatus.notFound);
+      });
+    }
+
+    test('covers the internal root and future nested routes', () async {
+      final handler = internalRoutesMiddleware(environment: const {})(
+        (_) => throw StateError('Disabled route must not run'),
+      );
+
+      for (final path in ['/internal', '/internal/', '/internal/new/nested']) {
+        final context = TestRequestContext(path: path);
+        expect(
+          (await handler(context.context)).statusCode,
+          HttpStatus.notFound,
+          reason: path,
+        );
+      }
+    });
+
+    test(
+      'preserves the handler and response when explicitly enabled',
+      () async {
+        final context = TestRequestContext(
+          path: '/internal/seed',
+          method: HttpMethod.post,
+        ).context;
+        final expected = Response(
+          statusCode: HttpStatus.created,
+          body: 'seeded',
+        );
+        var calls = 0;
+        final handler =
+            internalRoutesMiddleware(
+              environment: const {'ENABLE_INTERNAL_API': 'true'},
+            )((actualContext) {
+              calls++;
+              expect(actualContext, same(context));
+              return expected;
+            });
+
+        expect(await handler(context), same(expected));
+        expect(calls, 1);
+      },
+    );
+
+    test('preserves routes outside the internal path segment', () async {
+      final expected = Response(statusCode: HttpStatus.accepted);
+      final handler = internalRoutesMiddleware(environment: const {})(
+        (_) => expected,
+      );
+
+      for (final path in [
+        '/',
+        '/webhook',
+        '/webhooks/claim',
+        '/builds/claim',
+        '/teams',
+        '/internal-other',
+      ]) {
+        final context = TestRequestContext(path: path);
+        expect(await handler(context.context), same(expected), reason: path);
+      }
+    });
+
+    test(
+      'rejects disabled routes before CORS can answer a preflight',
+      () async {
+        final context = TestRequestContext(
+          path: '/internal/seed',
+          method: HttpMethod.options,
+          headers: {'Origin': 'https://dashboard.openci.org'},
+        );
+        Handler handler = (_) =>
+            throw StateError('Disabled route must not run');
+        handler = handler
+            .use(corsMiddleware(environment: const {}))
+            .use(internalRoutesMiddleware(environment: const {}));
+
+        final response = await handler(context.context);
+
+        expect(response.statusCode, HttpStatus.notFound);
+        expect(
+          response.headers,
+          isNot(contains('Access-Control-Allow-Origin')),
+        );
+      },
+    );
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       PORT: 8080
       DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-openci}}
       INTERNAL_API_KEY: ${INTERNAL_API_KEY:?INTERNAL_API_KEY environment variable is required}
+      ENABLE_INTERNAL_API: ${ENABLE_INTERNAL_API:-false}
       SECRET_ENCRYPTION_KEY: ${SECRET_ENCRYPTION_KEY:?SECRET_ENCRYPTION_KEY environment variable is required}
 
       GOOGLE_APPLICATION_CREDENTIALS: /app/credentials/firebase-service-account.json


### PR DESCRIPTION
The `/internal` seed and cleanup endpoints currently run in ordinary server deployments. Return 404 for the entire path unless `ENABLE_INTERNAL_API=true`, before authentication and CORS handling.

`genuineci dev start` sets the flag for its Compose subprocess while preserving other environment variables. `genuineci dev start --seed` continues to work without a manual environment-variable prefix.

Validation:
- Server: 570 tests passed, including PostgreSQL integration tests; static analysis and formatting passed.
- CLI: 335 tests passed; source analysis (`bin`, `lib`, `test`) and formatting passed. Package-wide checks encounter existing third-party code under the local `build/` directory; that directory was excluded from source checks.
- Compose flag forwarding/defaults and `git diff --check` passed; the complete diff was reviewed.

Mac/Tart VM startup and Ubuntu deployment have not been exercised.
