### PR TITLE
chore(server): add genuineci_server Dart package

### DIFF
--- a/apps/genuineci_server/bin/main.dart
+++ b/apps/genuineci_server/bin/main.dart
@@ -1,0 +1,1 @@
+void main() {}

--- a/apps/genuineci_server/pubspec.yaml
+++ b/apps/genuineci_server/pubspec.yaml
@@ -1,0 +1,9 @@
+name: genuineci_server
+description: GenuineCI server.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: ^3.11.5
+
+resolution: workspace

--- a/genuine_ci/paths.g.dart
+++ b/genuine_ci/paths.g.dart
@@ -20,6 +20,7 @@ extension type const WorkspaceRoot$Apps._(String _path) implements WorkspaceDire
   WorkspaceRoot$Apps$BuildJobWorker get buildJobWorker => const WorkspaceRoot$Apps$BuildJobWorker._("apps/build_job_worker");
   WorkspaceRoot$Apps$Dashboard get dashboard => const WorkspaceRoot$Apps$Dashboard._("apps/dashboard");
   WorkspaceRoot$Apps$GenuineciCli get genuineciCli => const WorkspaceRoot$Apps$GenuineciCli._("apps/genuineci_cli");
+  WorkspaceRoot$Apps$GenuineciServer get genuineciServer => const WorkspaceRoot$Apps$GenuineciServer._("apps/genuineci_server");
   WorkspaceRoot$Apps$OpenciServer get openciServer => const WorkspaceRoot$Apps$OpenciServer._("apps/openci_server");
 }
 
@@ -51,6 +52,10 @@ extension type const WorkspaceRoot$Apps$GenuineciCli._(String _path) implements 
   WorkspaceDirectory get bin => const WorkspaceDirectory("apps/genuineci_cli/bin");
   WorkspaceDirectory get lib => const WorkspaceDirectory("apps/genuineci_cli/lib");
   WorkspaceDirectory get test => const WorkspaceDirectory("apps/genuineci_cli/test");
+}
+
+extension type const WorkspaceRoot$Apps$GenuineciServer._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get bin => const WorkspaceDirectory("apps/genuineci_server/bin");
 }
 
 extension type const WorkspaceRoot$Apps$OpenciServer._(String _path) implements WorkspaceDirectory {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - apps/build_job_planner
   - apps/build_job_worker
   - apps/genuineci_cli
+  - apps/genuineci_server
   - apps/openci_server
   - genuine_ci
   - packages/genuine_ci


### PR DESCRIPTION
Add `apps/genuineci_server` alongside `apps/openci_server` as the starting package for the incremental Serverpod migration. Include an empty Dart entry point, register the package in the workspace, and regenerate workspace directory paths.

Validation:
- Formatting, static analysis of both server packages and `genuine_ci`, and execution of the new entry point passed.
- Existing `openci_server` unit tests: 561 passed.
- Workspace discovery and path generation tests: 85 passed.
