### PR TITLE
chore(client): declare http dependency for generated API client

### DIFF
--- a/packages/genuineci_api_client/pubspec.yaml
+++ b/packages/genuineci_api_client/pubspec.yaml
@@ -9,4 +9,5 @@ environment:
 resolution: workspace
 
 dependencies:
+  http: ^1.6.0
   serverpod_client: 4.0.0-rc.2


### PR DESCRIPTION
Serverpod 4.0.0-rc.2 generates a client that imports `package:http`. Declare `http: ^1.6.0` in `genuineci_api_client` to prepare for adding that generated code.

Validation: `flutter pub get --enforce-lockfile`, package formatting, static analysis (`--fatal-infos`), and full diff review passed. The workspace already resolves `http` 1.6.0, so the lockfile is unchanged. This package has no tests yet and is not covered by the current CI path filters.
