### PR TITLE
chore(client): allow empty constructor bodies in API client

### DIFF
--- a/packages/genuineci_api_client/analysis_options.yaml
+++ b/packages/genuineci_api_client/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../../analysis_options.yaml
+
+linter:
+  rules:
+    # Serverpod 4.0.0-rc.2 generates an empty body for the Client constructor.
+    empty_constructor_bodies: false


### PR DESCRIPTION
Serverpod 4.0.0-rc.2 emits `Client(...) : super(...) {}`, which triggers `empty_constructor_bodies` under the workspace lint rules. Add package analysis options that inherit the workspace settings and disable this one style rule in `genuineci_api_client`.

Validation: temporarily loaded the actual RC.2-generated client files and confirmed analysis fails on this lint before the setting and passes afterward. Final package formatting, fatal-info analysis, locked dependency resolution, and full diff review passed. This package has no automated tests or CI coverage yet.
