### PR TITLE
chore(server): add generated endpoint dispatcher

### DIFF
--- a/apps/genuineci_server/lib/src/generated/endpoints.dart
+++ b/apps/genuineci_server/lib/src/generated/endpoints.dart
@@ -1,0 +1,18 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _is;
+
+class Endpoints extends _is.EndpointDispatch {
+  @override
+  void initializeEndpoints(_is.Server server) {}
+}

--- a/genuine_ci/paths.g.dart
+++ b/genuine_ci/paths.g.dart
@@ -57,6 +57,7 @@ extension type const WorkspaceRoot$Apps$GenuineciCli._(String _path) implements 
 extension type const WorkspaceRoot$Apps$GenuineciServer._(String _path) implements WorkspaceDirectory {
   WorkspaceDirectory get bin => const WorkspaceDirectory("apps/genuineci_server/bin");
   WorkspaceDirectory get config => const WorkspaceDirectory("apps/genuineci_server/config");
+  WorkspaceDirectory get lib => const WorkspaceDirectory("apps/genuineci_server/lib");
 }
 
 extension type const WorkspaceRoot$Apps$OpenciServer._(String _path) implements WorkspaceDirectory {


### PR DESCRIPTION
Add the Serverpod 4.0.0-rc.2 generated `Endpoints` dispatcher for the current empty API definition. Refresh the workspace path definitions for the new server `lib` directory.

Validation:
- Forced regeneration leaves `endpoints.dart` byte-identical
- `flutter pub get --enforce-lockfile`, formatting, and fatal-info analysis of the server and workspace workflows passed
- 58 CLI tests for workspace path generation passed
- Complete 2-file diff reviewed

The new server does not yet have runtime tests or CI coverage.
