### PR TITLE
feat(server): add Hello world endpoint

### DIFF
--- a/.github/workflows/serverpod-ci.yml
+++ b/.github/workflows/serverpod-ci.yml
@@ -1,0 +1,68 @@
+name: Serverpod CI
+
+on:
+  push:
+    paths:
+      - "apps/genuineci_server/**"
+      - "packages/genuineci_api_client/**"
+      - "analysis_options.yaml"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - ".github/workflows/serverpod-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Serverpod API
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: "3.44.8"
+          cache: true
+
+      - name: Install workspace dependencies
+        run: flutter pub get --enforce-lockfile
+
+      - name: Install Serverpod CLI
+        run: dart pub global activate serverpod_cli 4.0.0-rc.2
+
+      - name: Regenerate server and API client
+        run: >-
+          dart pub global run serverpod_cli:serverpod_cli
+          --no-analytics --no-interactive generate
+          --directory apps/genuineci_server --force
+
+      - name: Verify generated files are committed
+        run: |
+          git diff --exit-code -- apps/genuineci_server packages/genuineci_api_client
+          test -z "$(git ls-files --others --exclude-standard -- apps/genuineci_server packages/genuineci_api_client)"
+
+      - name: Verify formatting
+        run: >-
+          dart format --output=none --set-exit-if-changed
+          apps/genuineci_server packages/genuineci_api_client
+
+      - name: Analyze server
+        run: dart analyze --fatal-infos apps/genuineci_server
+
+      - name: Analyze API client
+        run: dart analyze --fatal-infos packages/genuineci_api_client
+
+      - name: Test API over HTTP
+        working-directory: apps/genuineci_server
+        run: dart test integration_test --reporter expanded

--- a/apps/genuineci_server/README.md
+++ b/apps/genuineci_server/README.md
@@ -1,0 +1,47 @@
+# GenuineCI server
+
+Serverpod `4.0.0-rc.2` API. The first endpoint returns `Hello world` and runs
+without PostgreSQL or Redis.
+
+## Run locally
+
+From the repository root:
+
+```sh
+flutter pub get --enforce-lockfile
+cd apps/genuineci_server
+dart run bin/main.dart
+```
+
+In another terminal, from the repository root:
+
+```sh
+dart run packages/genuineci_api_client/example/hello.dart
+# Hello world
+```
+
+The generated client calls `client.greeting.hello()` at `http://localhost:8180/`.
+Stop the server with Ctrl+C.
+
+## Test
+
+From `apps/genuineci_server`:
+
+```sh
+dart test integration_test
+```
+
+The test starts the API on an available port and calls it over HTTP using the
+generated client.
+
+## Regenerate the API client
+
+From the repository root:
+
+```sh
+dart pub global activate serverpod_cli 4.0.0-rc.2
+dart pub global run serverpod_cli:serverpod_cli --no-analytics --no-interactive generate --directory apps/genuineci_server --force
+```
+
+Commit the generated server and client files together with endpoint changes.
+CI checks generation, formatting, static analysis, and the HTTP integration test.

--- a/apps/genuineci_server/bin/main.dart
+++ b/apps/genuineci_server/bin/main.dart
@@ -1,1 +1,6 @@
-void main() {}
+import 'package:genuineci_server/src/generated/serverpod.dart';
+
+Future<void> main(List<String> args) async {
+  final pod = Serverpod(args);
+  await pod.start();
+}

--- a/apps/genuineci_server/config/development.yaml
+++ b/apps/genuineci_server/config/development.yaml
@@ -1,0 +1,5 @@
+apiServer:
+  port: 8180
+  publicHost: localhost
+  publicPort: 8180
+  publicScheme: http

--- a/apps/genuineci_server/config/test.yaml
+++ b/apps/genuineci_server/config/test.yaml
@@ -1,0 +1,5 @@
+apiServer:
+  port: 0
+  publicHost: localhost
+  publicPort: 0
+  publicScheme: http

--- a/apps/genuineci_server/integration_test/greeting_test.dart
+++ b/apps/genuineci_server/integration_test/greeting_test.dart
@@ -1,0 +1,16 @@
+import 'package:genuineci_api_client/genuineci_api_client.dart' as api;
+import 'package:genuineci_server/src/generated/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('serves Hello world over HTTP', () async {
+    final pod = Serverpod(['--mode=test']);
+    addTearDown(() => pod.shutdown(exitProcess: false));
+    await pod.start(runInGuardedZone: false);
+
+    final client = api.Client('http://127.0.0.1:${pod.server.port}/');
+    addTearDown(client.close);
+
+    expect(await client.greeting.hello(), 'Hello world');
+  });
+}

--- a/apps/genuineci_server/lib/src/endpoints/greeting_endpoint.dart
+++ b/apps/genuineci_server/lib/src/endpoints/greeting_endpoint.dart
@@ -1,0 +1,6 @@
+import 'package:serverpod/serverpod.dart';
+
+/// The first GenuineCI API endpoint.
+class GreetingEndpoint extends Endpoint {
+  Future<String> hello(Session session) async => 'Hello world';
+}

--- a/apps/genuineci_server/lib/src/generated/endpoints.dart
+++ b/apps/genuineci_server/lib/src/generated/endpoints.dart
@@ -11,8 +11,34 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _is;
+import '../endpoints/greeting_endpoint.dart' as _imlzn9oq;
 
 class Endpoints extends _is.EndpointDispatch {
   @override
-  void initializeEndpoints(_is.Server server) {}
+  void initializeEndpoints(_is.Server server) {
+    var endpoints = <String, _is.Endpoint>{
+      'greeting': _imlzn9oq.GreetingEndpoint()
+        ..initialize(
+          server,
+          'greeting',
+          null,
+        ),
+    };
+    connectors['greeting'] = _is.EndpointConnector(
+      name: 'greeting',
+      endpoint: endpoints['greeting']!,
+      methodConnectors: {
+        'hello': _is.MethodConnector(
+          name: 'hello',
+          params: {},
+          call:
+              (
+                _is.Session session,
+                Map<String, dynamic> params,
+              ) async => (endpoints['greeting'] as _imlzn9oq.GreetingEndpoint)
+                  .hello(session),
+        ),
+      },
+    );
+  }
 }

--- a/apps/genuineci_server/lib/src/generated/protocol.yaml
+++ b/apps/genuineci_server/lib/src/generated/protocol.yaml
@@ -1,0 +1,2 @@
+greeting:
+  - hello:

--- a/apps/genuineci_server/lib/src/generated/serverpod.dart
+++ b/apps/genuineci_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:io' as _idi;
+import 'package:serverpod/serverpod.dart' as _is;
+import 'endpoints.dart' as _iavctuc6;
+import 'protocol.dart' as _il2as5qe;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _is.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _idi.Directory? serverDirectory,
+    _is.ServerpodConfig? config,
+    _is.ServerpodConfig Function(_is.ServerpodConfig)? configOverride,
+    _is.AuthenticationHandler? authenticationHandler,
+    _is.HealthCheckHandler? healthCheckHandler,
+    _is.HealthConfig? healthConfig,
+    _is.Headers? httpResponseHeaders,
+    _is.Headers? httpOptionsResponseHeaders,
+    _is.SecurityContextConfig? securityContextConfig,
+    _is.ExperimentalFeatures? experimentalFeatures,
+    _is.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _is.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _il2as5qe.Protocol(),
+         _iavctuc6.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/apps/genuineci_server/pubspec.yaml
+++ b/apps/genuineci_server/pubspec.yaml
@@ -10,3 +10,8 @@ resolution: workspace
 
 dependencies:
   serverpod: 4.0.0-rc.2
+
+dev_dependencies:
+  genuineci_api_client:
+    path: ../../packages/genuineci_api_client
+  test: ^1.31.0

--- a/genuine_ci/paths.g.dart
+++ b/genuine_ci/paths.g.dart
@@ -57,6 +57,7 @@ extension type const WorkspaceRoot$Apps$GenuineciCli._(String _path) implements 
 extension type const WorkspaceRoot$Apps$GenuineciServer._(String _path) implements WorkspaceDirectory {
   WorkspaceDirectory get bin => const WorkspaceDirectory("apps/genuineci_server/bin");
   WorkspaceDirectory get config => const WorkspaceDirectory("apps/genuineci_server/config");
+  WorkspaceDirectory get integrationTest => const WorkspaceDirectory("apps/genuineci_server/integration_test");
   WorkspaceDirectory get lib => const WorkspaceDirectory("apps/genuineci_server/lib");
 }
 
@@ -81,6 +82,7 @@ extension type const WorkspaceRoot$Packages$GenuineCi._(String _path) implements
 }
 
 extension type const WorkspaceRoot$Packages$GenuineciApiClient._(String _path) implements WorkspaceDirectory {
+  WorkspaceDirectory get example => const WorkspaceDirectory("packages/genuineci_api_client/example");
   WorkspaceDirectory get lib => const WorkspaceDirectory("packages/genuineci_api_client/lib");
 }
 

--- a/packages/genuineci_api_client/example/hello.dart
+++ b/packages/genuineci_api_client/example/hello.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+
+import 'package:genuineci_api_client/genuineci_api_client.dart';
+
+Future<void> main() async {
+  final client = Client('http://localhost:8180/');
+  try {
+    stdout.writeln(await client.greeting.hello());
+  } finally {
+    client.close();
+  }
+}

--- a/packages/genuineci_api_client/lib/genuineci_api_client.dart
+++ b/packages/genuineci_api_client/lib/genuineci_api_client.dart
@@ -1,2 +1,6 @@
 /// API client library for the GenuineCI server.
 library;
+
+export 'package:serverpod_client/serverpod_client.dart';
+
+export 'src/protocol/protocol.dart';

--- a/packages/genuineci_api_client/lib/src/protocol/client.dart
+++ b/packages/genuineci_api_client/lib/src/protocol/client.dart
@@ -1,0 +1,70 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'dart:async' as _ida;
+import 'package:http/http.dart' as _i85jenna;
+import 'package:serverpod_client/serverpod_client.dart' as _isc;
+import 'protocol.dart' as _il2as5qe;
+
+/// The first GenuineCI API endpoint.
+/// {@category Endpoint}
+class EndpointGreeting extends _isc.EndpointRef {
+  EndpointGreeting(_isc.EndpointCaller caller) : super(caller);
+
+  @override
+  String get name => 'greeting';
+
+  _ida.Future<String> hello() => caller.callServerEndpoint<String>(
+    'greeting',
+    'hello',
+    {},
+  );
+}
+
+class Client extends _isc.ServerpodClientShared {
+  Client(
+    String host, {
+    dynamic securityContext,
+    Duration? streamingConnectionTimeout,
+    Duration? connectionTimeout,
+    Function(
+      _isc.MethodCallContext,
+      Object,
+      StackTrace,
+    )?
+    onFailedCall,
+    Function(_isc.MethodCallContext)? onSucceededCall,
+    bool? disconnectStreamsOnLostInternetConnection,
+    _i85jenna.Client? httpClientOverride,
+  }) : super(
+         host,
+         _il2as5qe.Protocol(),
+         securityContext: securityContext,
+         streamingConnectionTimeout: streamingConnectionTimeout,
+         connectionTimeout: connectionTimeout,
+         onFailedCall: onFailedCall,
+         onSucceededCall: onSucceededCall,
+         disconnectStreamsOnLostInternetConnection:
+             disconnectStreamsOnLostInternetConnection,
+         httpClientOverride: httpClientOverride,
+       ) {
+    greeting = EndpointGreeting(this);
+  }
+
+  late final EndpointGreeting greeting;
+
+  @override
+  Map<String, _isc.EndpointRef> get endpointRefLookup => {'greeting': greeting};
+
+  @override
+  Map<String, _isc.ModuleEndpointCaller> get moduleLookup => {};
+}

--- a/packages/genuineci_api_client/lib/src/protocol/protocol.dart
+++ b/packages/genuineci_api_client/lib/src/protocol/protocol.dart
@@ -1,0 +1,95 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+// ignore_for_file: dead_code, unnecessary_type_check
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _isc;
+export 'client.dart';
+
+class Protocol extends _isc.SerializationManager {
+  Protocol._();
+
+  factory Protocol() => _instance;
+
+  static final Protocol _instance = Protocol._();
+
+  static String? getClassNameFromObjectJson(dynamic data) {
+    if (data is! Map) return null;
+    final className = data['__className__'] as String?;
+    return className;
+  }
+
+  @override
+  T deserialize<T>(
+    dynamic data, [
+    Type? t,
+  ]) {
+    t ??= T;
+
+    final dataClassName = getClassNameFromObjectJson(data);
+    if (dataClassName != null && dataClassName != getClassNameForType(t)) {
+      try {
+        return deserializeByClassName({
+          'className': dataClassName,
+          'data': data,
+        });
+      } on _isc.DeserializationClassNameNotFoundException catch (_) {
+        // If the className is not recognized (e.g., older client receiving
+        // data with a new subtype), fall back to deserializing without the
+        // className, using the expected type T.
+      }
+    }
+
+    return super.deserialize<T>(data, t);
+  }
+
+  static String? getClassNameForType(Type type) {
+    return switch (type) {
+      _ => null,
+    };
+  }
+
+  @override
+  String? getClassNameForObject(Object? data) {
+    String? className = super.getClassNameForObject(data);
+    if (className != null) return className;
+
+    if (data is Map<String, dynamic> && data['__className__'] is String) {
+      return (data['__className__'] as String).replaceFirst('genuineci.', '');
+    }
+
+    return null;
+  }
+
+  @override
+  dynamic deserializeByClassName(Map<String, dynamic> data) {
+    var dataClassName = data['className'];
+    if (dataClassName is! String) {
+      return super.deserializeByClassName(data);
+    }
+    return super.deserializeByClassName(data);
+  }
+
+  @override
+  String getModuleName() => 'genuineci';
+
+  /// Maps any `Record`s known to this [Protocol] to their JSON representation
+  ///
+  /// Throws in case the record type is not known.
+  ///
+  /// This method will return `null` (only) for `null` inputs.
+  Map<String, dynamic>? mapRecordToJson(Record? record) {
+    if (record == null) {
+      return null;
+    }
+    throw Exception('Unsupported record type ${record.runtimeType}');
+  }
+}


### PR DESCRIPTION
Start `genuineci_server` and expose the first working endpoint: `client.greeting.hello()` returns `Hello world` over HTTP. It runs with Serverpod 4.0.0-rc.2 and requires no PostgreSQL or Redis.

Includes the generated server/client wiring, a runnable client example, local startup instructions, and one HTTP integration test. A dedicated CI workflow checks generated files, formatting, analysis, and the endpoint round trip.

Validation:
- Started `dart run bin/main.dart` and confirmed the documented client example prints `Hello world`
- HTTP integration test passed without a database; workspace path tests passed (58 tests)
- Formatting, fatal-info analysis for both packages and `genuine_ci`, and `actionlint` passed
- Forced Serverpod regeneration produced no changes; reviewed the complete diff
