### PR TITLE
feat(worker): add API helper for step log chunks

### DIFF
--- a/apps/build_job_worker/lib/build_job_worker.dart
+++ b/apps/build_job_worker/lib/build_job_worker.dart
@@ -17,3 +17,4 @@ export 'src/orchard/write_file.dart';
 export 'src/resolve_github_installation_token.dart';
 export 'src/run_build_job_worker.dart';
 export 'src/run_workflow.dart';
+export 'src/send_step_log_chunk.dart' show sendStepLogChunk;

--- a/apps/build_job_worker/lib/src/send_step_log_chunk.dart
+++ b/apps/build_job_worker/lib/src/send_step_log_chunk.dart
@@ -1,0 +1,41 @@
+import 'package:meta/meta.dart';
+import 'package:openci_shared/openci_shared.dart';
+
+Future<void> sendStepLogChunk({
+  required OpenCiApiService api,
+  required String jobId,
+  required String runId,
+  required String stepId,
+  required List<String> lines,
+}) async {
+  if (lines.isEmpty) return;
+
+  final bool isSuccessful;
+  final int statusCode;
+  try {
+    final response = await api.appendStepLog(
+      jobId,
+      runId,
+      stepId,
+      buildStepLogPayload(lines),
+    );
+    isSuccessful = response.isSuccessful;
+    statusCode = response.statusCode;
+  } catch (error, stackTrace) {
+    Error.throwWithStackTrace(
+      StateError('Failed to send step log chunk: ${error.runtimeType}.'),
+      stackTrace,
+    );
+  }
+
+  if (!isSuccessful) {
+    throw StateError('Failed to send step log chunk: HTTP $statusCode.');
+  }
+}
+
+@visibleForTesting
+Map<String, dynamic> buildStepLogPayload(List<String> lines) => {
+  'logs': [
+    for (final line in lines) {'message': line},
+  ],
+};

--- a/apps/build_job_worker/test/src/send_step_log_chunk_test.dart
+++ b/apps/build_job_worker/test/src/send_step_log_chunk_test.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:build_job_worker/build_job_worker.dart';
+import 'package:build_job_worker/src/send_step_log_chunk.dart'
+    show buildStepLogPayload;
+import 'package:mocktail/mocktail.dart';
+import 'package:openci_shared/openci_shared.dart';
+import 'package:openci_shared/test_helpers.dart';
+import 'package:test/test.dart';
+
+class _MockOpenCiApiService extends Mock implements OpenCiApiService {}
+
+void main() {
+  late OpenCiApiService api;
+  const lines = ['first', '', '日本語のログ', 'first'];
+  const payload = {
+    'logs': [
+      {'message': 'first'},
+      {'message': ''},
+      {'message': '日本語のログ'},
+      {'message': 'first'},
+    ],
+  };
+
+  Future<void> send(List<String> lines) => sendStepLogChunk(
+    api: api,
+    jobId: 'job-1',
+    runId: 'run-1',
+    stepId: 'step-1',
+    lines: lines,
+  );
+
+  group('buildStepLogPayload', () {
+    test('returns an empty logs list for empty input', () {
+      expect(buildStepLogPayload([]), {'logs': <Map<String, String>>[]});
+    });
+
+    test('wraps one line in a message entry', () {
+      expect(buildStepLogPayload(['build started']), {
+        'logs': [
+          {'message': 'build started'},
+        ],
+      });
+    });
+
+    test('preserves line order and repeated messages', () {
+      expect(buildStepLogPayload(lines), payload);
+    });
+
+    test('preserves empty and whitespace-only lines without trimming', () {
+      expect(buildStepLogPayload(['', ' ', '\t', '  indented  ']), {
+        'logs': [
+          {'message': ''},
+          {'message': ' '},
+          {'message': '\t'},
+          {'message': '  indented  '},
+        ],
+      });
+    });
+
+    test('preserves special characters through JSON encoding', () {
+      const message =
+          '日本語 🚀 "quoted" \\path\nnext\r\n\t\u001b[31mred\u001b[0m';
+      const expected = {
+        'logs': [
+          {'message': message},
+        ],
+      };
+
+      final result = buildStepLogPayload([message]);
+
+      expect(result, expected);
+      expect(jsonDecode(jsonEncode(result)), expected);
+    });
+
+    test('leaves the input intact and snapshots it before later changes', () {
+      final buffer = ['first', 'second'];
+
+      final result = buildStepLogPayload(buffer);
+
+      expect(buffer, ['first', 'second']);
+      buffer[0] = 'changed';
+      buffer.add('late');
+      expect(result, {
+        'logs': [
+          {'message': 'first'},
+          {'message': 'second'},
+        ],
+      });
+    });
+  });
+
+  group('sendStepLogChunk', () {
+    setUp(() => api = _MockOpenCiApiService());
+
+    test(
+      'sends all lines in one request, preserving order and blanks',
+      () async {
+        when(
+          () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+        ).thenAnswer((_) async => createMockResponse<void>(null));
+
+        await send(lines);
+
+        verify(
+          () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+        ).called(1);
+        verifyNoMoreInteractions(api);
+      },
+    );
+
+    test('does not send an empty chunk', () async {
+      await send([]);
+
+      verifyZeroInteractions(api);
+    });
+
+    test(
+      'reports an HTTP failure without exposing the response body',
+      () async {
+        when(
+          () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+        ).thenAnswer(
+          (_) async => createMockResponse<void>(
+            null,
+            statusCode: 503,
+          ).copyWith<void>(bodyError: 'private response body'),
+        );
+
+        await expectLater(
+          send(lines),
+          throwsA(
+            isA<StateError>().having(
+              (error) => error.message,
+              'message',
+              'Failed to send step log chunk: HTTP 503.',
+            ),
+          ),
+        );
+        verify(
+          () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+        ).called(1);
+        verifyNoMoreInteractions(api);
+      },
+    );
+
+    test('reports a transport failure and preserves its stack', () async {
+      final stackTrace = StackTrace.fromString('Log delivery failed here');
+      when(
+        () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+      ).thenAnswer(
+        (_) => Future.error(
+          TimeoutException('private request details'),
+          stackTrace,
+        ),
+      );
+
+      try {
+        await send(lines);
+        fail('Expected log delivery to fail');
+      } on StateError catch (error, actualStackTrace) {
+        expect(
+          error.message,
+          'Failed to send step log chunk: TimeoutException.',
+        );
+        expect(actualStackTrace.toString(), stackTrace.toString());
+      }
+      verify(
+        () => api.appendStepLog('job-1', 'run-1', 'step-1', payload),
+      ).called(1);
+      verifyNoMoreInteractions(api);
+    });
+  });
+}


### PR DESCRIPTION
worker から複数行のステップログを既存の `appendStepLog` API へ1リクエストで渡すための `sendStepLogChunk` を追加します。空チャンクは送信せず、HTTPエラーと通信例外は呼び出し元へ伝えます。

payload の生成を `@visibleForTesting` の `buildStepLogPayload` に切り出し、順序・重複・空行・特殊文字の保持と、入力リストの変更から独立した結果になることを直接テストします。API呼び出しとエラー処理を合わせて10件のテストを追加しています。

Lokiからの移行に向けた準備として、今回の対象は送信関数とテストです。実行処理への接続とバッファリングは後続PRで行います。

検証（`apps/build_job_worker`）:

- `dart format --output=none --set-exit-if-changed lib test integration_test bin`: 成功
- `dart analyze --fatal-infos .`: 指摘なし
- `env -u GIT_ASKPASS -u SSH_ASKPASS dart test test integration_test --reporter expanded`: 363件成功

差分全体をレビューし、`git diff --cached --check` も通過しています。新しい送信関数はAPIのモックで検証しており、実API・PostgreSQLへの保存のE2E検証は行っていません。
