### PR TITLE
feat(worker): send VM preparation logs through the API

### DIFF
--- a/apps/build_job_worker/integration_test/startup_test.dart
+++ b/apps/build_job_worker/integration_test/startup_test.dart
@@ -164,6 +164,7 @@ void main() {
         final deletion = Completer<HttpRequest>();
         final updates = <(String, Map<String, dynamic>)>[];
         final logs = <Map<String, dynamic>>[];
+        final apiLogs = <dynamic>[];
         var claims = 0;
         late String runId;
         late String vmName;
@@ -194,6 +195,10 @@ void main() {
                 'success': true,
                 'secretsContent': 'TEST_SECRET=test-secret-value',
               });
+            case ('POST', final path)
+                when path == '/builds/job-1/runs/$runId/steps/prepare_vm/logs':
+              apiLogs.addAll((await _body(request))['logs'] as List<dynamic>);
+              await _reply(request, {'success': true});
             case ('PATCH', final path) when path == '/builds/job-1/runs/$runId':
               updates.add(('run', await _body(request)));
               await _reply(request, null, statusCode: 204);
@@ -305,7 +310,14 @@ void main() {
           'status': 'completed',
           'conclusion': conclusion,
         });
-        expect(logs, hasLength(10));
+        expect(apiLogs, [
+          {
+            'message':
+                'Creating VM from test-base-macos and waiting for it to start.',
+          },
+          {'message': 'VM is ready.'},
+        ]);
+        expect(logs, hasLength(8));
         final streams = logs
             .map(
               (log) =>
@@ -351,13 +363,8 @@ void main() {
                   'step_log',
             )
             .toList();
-        expect(outputLogs, hasLength(4));
+        expect(outputLogs, hasLength(2));
         for (final (index, (stepId, message)) in [
-          (
-            'prepare_vm',
-            'Creating VM from test-base-macos and waiting for it to start.',
-          ),
-          ('prepare_vm', 'VM is ready.'),
           ('checkout', 'checkout output'),
           ('run_workflow', 'workflow output'),
         ].indexed) {

--- a/apps/build_job_worker/lib/src/execute_build_job.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job.dart
@@ -16,6 +16,7 @@ import 'orchard/orchard_api_client.dart';
 import 'orchard/prepare_vm.dart';
 import 'resolve_github_installation_token.dart';
 import 'run_workflow.dart';
+import 'send_step_log_chunk.dart';
 
 Future<BuildJobStatus> executeBuildJob({
   required OpenCiApiService api,
@@ -52,6 +53,16 @@ Future<BuildJobStatus> executeBuildJob({
       'step_log': ?logMessage,
     }.entries) {
       try {
+        if (entry.key == 'step_log') {
+          await sendStepLogChunk(
+            api: api,
+            jobId: job.id,
+            runId: runId,
+            stepId: step.id,
+            lines: [entry.value],
+          ).timeout(const Duration(seconds: 10));
+          continue;
+        }
         await pushLogToLoki(
           client: lokiClient,
           lokiUrl: config.internalLokiUrl,

--- a/apps/build_job_worker/test/src/execute_build_job_test.dart
+++ b/apps/build_job_worker/test/src/execute_build_job_test.dart
@@ -51,6 +51,7 @@ void main() {
   late Map<String, Map<String, dynamic>> completions;
   late List<(Object, StackTrace)> errors;
   late List<http.Request> logRequests;
+  late List<String> apiLogs;
   late Map<String, Object> failures;
   late Map<String, Completer<void>> pending;
   late Future<http.Response> Function(http.Request) respondToLog;
@@ -108,19 +109,6 @@ void main() {
       })
       .toList();
 
-  List<String> stepLogs(String stepId) => logRequests
-      .map(_lokiStream)
-      .where((stream) {
-        final labels = stream['stream'] as Map<String, dynamic>;
-        return labels['type'] == 'step_log' && labels['step_id'] == stepId;
-      })
-      .map((stream) {
-        final values =
-            (stream['values'] as List<dynamic>).single as List<dynamic>;
-        return values[1] as String;
-      })
-      .toList();
-
   setUpAll(() {
     registerFallbackValue((String line, String stream) {});
   });
@@ -137,6 +125,7 @@ void main() {
     completions = {};
     errors = [];
     logRequests = [];
+    apiLogs = [];
     failures = {};
     pending = {};
     leaseId = 'lease-1';
@@ -168,6 +157,16 @@ void main() {
       final body = invocation.positionalArguments[1] as Map<String, dynamic>;
       runIds.add(body['id'] as String);
       await record('createRun');
+      return createMockResponse<void>(null);
+    });
+    when(
+      () => api.appendStepLog(job.id, any(), 'prepare_vm', any()),
+    ).thenAnswer((invocation) async {
+      expect(invocation.positionalArguments[1], runIds.single);
+      final body = invocation.positionalArguments[3] as Map<String, dynamic>;
+      final entry =
+          (body['logs'] as List<dynamic>).single as Map<String, dynamic>;
+      apiLogs.add(entry['message'] as String);
       return createMockResponse<void>(null);
     });
     when(() => api.resolveInstallationToken(job.id)).thenAnswer((_) async {
@@ -340,14 +339,12 @@ void main() {
         expect(steps.last.createdAt, steps.first.createdAt);
         expect(steps.last.updatedAt.isBefore(steps.first.updatedAt), isFalse);
 
-        expect(stepLogs('prepare_vm'), [
+        expect(apiLogs, [
           'Creating VM from test-macos-image and waiting for it to start.',
           'VM is ready.',
         ]);
-        expect(logRequests, hasLength(10));
+        expect(logRequests, hasLength(8));
         for (final (index, step) in [
-          'prepare_vm',
-          'prepare_vm',
           'prepare_vm',
           'prepare_vm',
           'checkout',
@@ -401,7 +398,7 @@ void main() {
           stepEvents('prepare_vm').single.status,
           BuildJobStatus.IN_PROGRESS,
         );
-        expect(stepLogs('prepare_vm'), [
+        expect(apiLogs, [
           'Creating VM from test-macos-image and waiting for it to start.',
         ]);
         expect(commands, isEmpty);
@@ -571,7 +568,7 @@ void main() {
                 : BuildJobStatus.SUCCESS,
           ],
         ]);
-        expect(stepLogs('prepare_vm'), [
+        expect(apiLogs, [
           if (!['createRun', 'token'].contains(stage)) ...[
             'Creating VM from test-macos-image and waiting for it to start.',
             ['createVm', 'waitVm'].contains(stage)
@@ -730,13 +727,31 @@ void main() {
       });
     }
 
+    test('reports API log failures without failing the workflow', () async {
+      when(
+        () => api.appendStepLog(job.id, any(), 'prepare_vm', any()),
+      ).thenAnswer(
+        (_) async => createMockResponse<void>(null, statusCode: 503),
+      );
+
+      expect(await execute(), BuildJobStatus.SUCCESS);
+
+      expectCompletion(BuildJobStatus.SUCCESS);
+      expect(errors, hasLength(2));
+      expect(
+        errors.map((entry) => entry.$1.toString()),
+        everyElement(contains('HTTP 503')),
+      );
+      expect(deletedVms, ['lease-1']);
+    });
+
     test('reports Loki failures without failing the workflow', () async {
       respondToLog = (_) async => http.Response('', 503);
 
       expect(await execute(), BuildJobStatus.SUCCESS);
 
       expectCompletion(BuildJobStatus.SUCCESS);
-      expect(errors, hasLength(10));
+      expect(errors, hasLength(8));
       expect(deletedVms, ['lease-1']);
     });
 
@@ -748,7 +763,7 @@ void main() {
 
       expectCompletion(BuildJobStatus.FAILURE);
       expect(stepEvents('prepare_vm').last.status, BuildJobStatus.FAILURE);
-      expect(errors, hasLength(5));
+      expect(errors, hasLength(3));
       expect(errors.last.$1, same(vmError));
       expect(errors.last.$2.toString(), sourceStack.toString());
       expect(deletedVms, ['lease-1']);
@@ -811,6 +826,16 @@ void main() {
     ]) {
       test('continues after $stepId $type delivery times out', () async {
         final response = Completer<http.Response>();
+        if (type == 'step_log') {
+          when(
+            () => api.appendStepLog(job.id, any(), stepId, any()),
+          ).thenAnswer((_) async {
+            if (stepEvents(stepId).last.status == BuildJobStatus.IN_PROGRESS) {
+              await response.future;
+            }
+            return createMockResponse<void>(null);
+          });
+        }
         respondToLog = (request) {
           final labels = _lokiStream(request)['stream'] as Map<String, dynamic>;
           if (labels['type'] == type &&


### PR DESCRIPTION
VM準備の開始・完了・失敗メッセージを、`sendStepLogChunk` で既存のステップログAPIへ送信するようにします。`reportStep` の `step_log` を1行ずつ送り、送信失敗や10秒のタイムアウトを既存のエラー通知経路へ渡します。

対象はVM準備ログのみです。ステップ状態とcheckout/workflowのコマンド出力の移行は後続対応とします。本体は11行追加で、関連するテスト2ファイルを合わせて更新しています。

検証（`apps/build_job_worker`）:

- `dart format --output=none --set-exit-if-changed lib test integration_test bin`: 成功
- `dart analyze --fatal-infos .`: 指摘なし
- `env -u GIT_ASKPASS -u SSH_ASKPASS dart test test integration_test --reporter expanded`: 364件成功
- 差分全体のレビューと `git diff --check`: 完了

API送信はモックとローカルのテスト用HTTPサーバーで検証しています。実PostgreSQLへの保存と、PGを参照する画面表示は未検証です。
