### PR TITLE
refactor(worker): type step report entries with an enum

### DIFF
--- a/apps/build_job_worker/lib/src/execute_build_job.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job.dart
@@ -18,6 +18,15 @@ import 'resolve_github_installation_token.dart';
 import 'run_workflow.dart';
 import 'send_step_log_chunk.dart';
 
+enum _StepEntryType {
+  stepEvent('step_event'),
+  stepLog('step_log');
+
+  const _StepEntryType(this.value);
+
+  final String value;
+}
+
 Future<BuildJobStatus> executeBuildJob({
   required OpenCiApiService api,
   required OrchardApiClient orchardApi,
@@ -48,12 +57,12 @@ Future<BuildJobStatus> executeBuildJob({
   final errors = <(Object, StackTrace)>[];
 
   Future<void> reportStep(BuildStep step, {String? logMessage}) async {
-    for (final entry in {
-      'step_event': jsonEncode(step.toJson()),
-      'step_log': ?logMessage,
+    for (final entry in <_StepEntryType, String>{
+      _StepEntryType.stepEvent: jsonEncode(step.toJson()),
+      _StepEntryType.stepLog: ?logMessage,
     }.entries) {
       try {
-        if (entry.key == 'step_log') {
+        if (entry.key == _StepEntryType.stepLog) {
           await sendStepLogChunk(
             api: api,
             jobId: job.id,
@@ -69,7 +78,7 @@ Future<BuildJobStatus> executeBuildJob({
           runId: runId,
           jobId: job.id,
           stepId: step.id,
-          type: entry.key,
+          type: entry.key.value,
           message: entry.value,
         ).timeout(const Duration(seconds: 10));
       } catch (error, stackTrace) {


### PR DESCRIPTION
`reportStep` の種類判定を文字列から `_StepEntryType` enumへ置き換えます。Mapのキーもenum型にし、Lokiに渡す箇所で `.value` から既存の文字列を取り出します。変更は `execute_build_job.dart` の1ファイルです。

検証（`apps/build_job_worker`）:

- `dart format --output=none --set-exit-if-changed lib test integration_test bin`: 成功
- `dart analyze --fatal-infos .`: 指摘なし
- `env -u GIT_ASKPASS -u SSH_ASKPASS dart test test integration_test --reporter expanded`: 364件成功
- 差分全体のレビューと `git diff --check`: 完了

既存テストで送信先とpayloadを確認しています。実PostgreSQLへの保存は未検証です。
