### PR TITLE
refactor(worker): extract step reporting from job execution

### DIFF
--- a/apps/build_job_worker/lib/build_job_worker.dart
+++ b/apps/build_job_worker/lib/build_job_worker.dart
@@ -5,7 +5,7 @@ export 'src/complete_build_run.dart';
 export 'src/complete_github_check_run.dart';
 export 'src/config.dart';
 export 'src/create_build_run.dart';
-export 'src/execute_build_job.dart';
+export 'src/execute_build_job/execute_build_job.dart';
 export 'src/fetch_job_secrets.dart';
 export 'src/loki/push_log_to_loki.dart';
 export 'src/orchard/calculate_max_concurrent_jobs.dart'

--- a/apps/build_job_worker/lib/src/execute_build_job/execute_build_job.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job/execute_build_job.dart
@@ -1,31 +1,20 @@
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:http/http.dart' as http;
 import 'package:openci_shared/openci_shared.dart';
 
-import 'checkout_repository.dart';
-import 'complete_build_job.dart';
-import 'complete_build_run.dart';
-import 'complete_github_check_run.dart';
-import 'config.dart';
-import 'create_build_run.dart';
-import 'fetch_job_secrets.dart';
-import 'loki/push_log_to_loki.dart';
-import 'orchard/orchard_api_client.dart';
-import 'orchard/prepare_vm.dart';
-import 'resolve_github_installation_token.dart';
-import 'run_workflow.dart';
-import 'send_step_log_chunk.dart';
-
-enum _StepEntryType {
-  stepEvent('step_event'),
-  stepLog('step_log');
-
-  const _StepEntryType(this.value);
-
-  final String value;
-}
+import '../checkout_repository.dart';
+import '../complete_build_job.dart';
+import '../complete_build_run.dart';
+import '../complete_github_check_run.dart';
+import '../config.dart';
+import '../create_build_run.dart';
+import '../fetch_job_secrets.dart';
+import '../orchard/orchard_api_client.dart';
+import '../orchard/prepare_vm.dart';
+import 'report_step.dart' as step_reporting;
+import '../resolve_github_installation_token.dart';
+import '../run_workflow.dart';
 
 Future<BuildJobStatus> executeBuildJob({
   required OpenCiApiService api,
@@ -56,36 +45,17 @@ Future<BuildJobStatus> executeBuildJob({
   String? leaseId;
   final errors = <(Object, StackTrace)>[];
 
-  Future<void> reportStep(BuildStep step, {String? logMessage}) async {
-    for (final entry in <_StepEntryType, String>{
-      _StepEntryType.stepEvent: jsonEncode(step.toJson()),
-      _StepEntryType.stepLog: ?logMessage,
-    }.entries) {
-      try {
-        if (entry.key == _StepEntryType.stepLog) {
-          await sendStepLogChunk(
-            api: api,
-            jobId: job.id,
-            runId: runId,
-            stepId: step.id,
-            lines: [entry.value],
-          ).timeout(const Duration(seconds: 10));
-          continue;
-        }
-        await pushLogToLoki(
-          client: lokiClient,
-          lokiUrl: config.internalLokiUrl,
-          runId: runId,
-          jobId: job.id,
-          stepId: step.id,
-          type: entry.key.value,
-          message: entry.value,
-        ).timeout(const Duration(seconds: 10));
-      } catch (error, stackTrace) {
-        errors.add((error, stackTrace));
-      }
-    }
-  }
+  Future<void> reportStep(BuildStep step, {String? logMessage}) =>
+      step_reporting.reportStep(
+        api: api,
+        lokiClient: lokiClient,
+        lokiUrl: config.internalLokiUrl,
+        jobId: job.id,
+        runId: runId,
+        step: step,
+        logMessage: logMessage,
+        onError: (error, stackTrace) => errors.add((error, stackTrace)),
+      );
 
   try {
     await createBuildRun(api: api, jobId: job.id, runId: runId);

--- a/apps/build_job_worker/lib/src/execute_build_job/report_step.dart
+++ b/apps/build_job_worker/lib/src/execute_build_job/report_step.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:openci_shared/openci_shared.dart';
+
+import '../loki/push_log_to_loki.dart';
+import '../send_step_log_chunk.dart';
+
+enum _StepEntryType {
+  stepEvent('step_event'),
+  stepLog('step_log');
+
+  const _StepEntryType(this.value);
+
+  final String value;
+}
+
+Future<void> reportStep({
+  required OpenCiApiService api,
+  required http.Client lokiClient,
+  required String lokiUrl,
+  required String jobId,
+  required String runId,
+  required BuildStep step,
+  required void Function(Object error, StackTrace stackTrace) onError,
+  String? logMessage,
+}) async {
+  for (final entry in <_StepEntryType, String>{
+    _StepEntryType.stepEvent: jsonEncode(step.toJson()),
+    _StepEntryType.stepLog: ?logMessage,
+  }.entries) {
+    try {
+      if (entry.key == _StepEntryType.stepLog) {
+        await sendStepLogChunk(
+          api: api,
+          jobId: jobId,
+          runId: runId,
+          stepId: step.id,
+          lines: [entry.value],
+        ).timeout(const Duration(seconds: 10));
+        continue;
+      }
+      await pushLogToLoki(
+        client: lokiClient,
+        lokiUrl: lokiUrl,
+        runId: runId,
+        jobId: jobId,
+        stepId: step.id,
+        type: entry.key.value,
+        message: entry.value,
+      ).timeout(const Duration(seconds: 10));
+    } catch (error, stackTrace) {
+      onError(error, stackTrace);
+    }
+  }
+}


### PR DESCRIPTION
`executeBuildJob` 内のステップ報告処理と `_StepEntryType` を `report_step.dart` に切り出し、ジョブ実行処理から分離します。2ファイルを `execute_build_job/` にまとめ、関連する import と export を更新しました。

送信先、送信順序、10秒のタイムアウト、エラーを蓄積して後片付け後に報告する動作は維持しています。

検証:
- 差分全体のレビューと `git diff --check`
- `dart format --output=none --set-exit-if-changed lib test bin`
- `dart analyze --fatal-infos .`
- `dart test test --reporter expanded`（316件）
