### PR TITLE
refactor(server): accept shared BuildStep in upsertBuildStep

### DIFF
--- a/apps/openci_server/lib/build_job/build_job_dao.dart
+++ b/apps/openci_server/lib/build_job/build_job_dao.dart
@@ -145,8 +145,19 @@ class BuildJobDao extends DatabaseAccessor<AppDatabase>
     }
   }
 
-  Future<void> insertBuildStep(DriftBuildStep step) =>
-      into(buildSteps).insertOnConflictUpdate(step);
+  Future<void> saveStep(BuildStep step) =>
+      into(buildSteps).insertOnConflictUpdate(
+        DriftBuildStep(
+          id: step.id,
+          runId: step.runId,
+          name: step.name,
+          status: step.status,
+          durationMs: step.durationMs,
+          stepOrder: step.stepOrder,
+          createdAt: step.createdAt,
+          updatedAt: step.updatedAt,
+        ),
+      );
 
   Future<List<DriftBuildStep>> getBuildSteps(String runId) =>
       (select(buildSteps)

--- a/apps/openci_server/lib/build_job/build_job_dao.dart
+++ b/apps/openci_server/lib/build_job/build_job_dao.dart
@@ -145,7 +145,7 @@ class BuildJobDao extends DatabaseAccessor<AppDatabase>
     }
   }
 
-  Future<void> saveStep(BuildStep step) =>
+  Future<void> upsertBuildStep(BuildStep step) =>
       into(buildSteps).insertOnConflictUpdate(
         DriftBuildStep(
           id: step.id,

--- a/apps/openci_server/test/db/build_job_dao_test.dart
+++ b/apps/openci_server/test/db/build_job_dao_test.dart
@@ -144,10 +144,12 @@ void main() {
           createdAt: DateTime.utc(2026, 9, 1),
           updatedAt: DateTime.utc(2026, 9, 1),
         );
-        await dao.saveStep(first.copyWith(id: 'second', stepOrder: 1));
-        await dao.saveStep(first.copyWith(id: 'other-run', runId: 'run-b'));
-        await dao.saveStep(first);
-        await dao.saveStep(
+        await dao.upsertBuildStep(first.copyWith(id: 'second', stepOrder: 1));
+        await dao.upsertBuildStep(
+          first.copyWith(id: 'other-run', runId: 'run-b'),
+        );
+        await dao.upsertBuildStep(first);
+        await dao.upsertBuildStep(
           first.copyWith(status: BuildJobStatus.SUCCESS, durationMs: 10),
         );
 

--- a/apps/openci_server/test/db/build_job_dao_test.dart
+++ b/apps/openci_server/test/db/build_job_dao_test.dart
@@ -134,7 +134,7 @@ void main() {
     test(
       'steps are ordered within a run and upsert preserves a single row',
       () async {
-        final first = DriftBuildStep(
+        final first = BuildStep(
           id: 'first',
           runId: 'run-a',
           name: 'Checkout',
@@ -144,19 +144,22 @@ void main() {
           createdAt: DateTime.utc(2026, 9, 1),
           updatedAt: DateTime.utc(2026, 9, 1),
         );
-        await dao.insertBuildStep(first.copyWith(id: 'second', stepOrder: 1));
-        await dao.insertBuildStep(
-          first.copyWith(id: 'other-run', runId: 'run-b'),
-        );
-        await dao.insertBuildStep(first);
-        await dao.insertBuildStep(
+        await dao.saveStep(first.copyWith(id: 'second', stepOrder: 1));
+        await dao.saveStep(first.copyWith(id: 'other-run', runId: 'run-b'));
+        await dao.saveStep(first);
+        await dao.saveStep(
           first.copyWith(status: BuildJobStatus.SUCCESS, durationMs: 10),
         );
 
         final steps = await dao.getBuildSteps('run-a');
         expect(steps.map((step) => step.id), ['first', 'second']);
+        expect(steps.first.runId, first.runId);
+        expect(steps.first.name, first.name);
         expect(steps.first.status, BuildJobStatus.SUCCESS);
         expect(steps.first.durationMs, 10);
+        expect(steps.first.stepOrder, first.stepOrder);
+        expect(steps.first.createdAt.toUtc(), first.createdAt);
+        expect(steps.first.updatedAt.toUtc(), first.updatedAt);
         expect(await dao.getBuildSteps('missing'), isEmpty);
       },
     );

--- a/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
@@ -55,7 +55,7 @@ void main() {
     test('returns stored build step logs', () async {
       await _seedBuildJob(db);
       final now = DateTime.now().toUtc();
-      await db.buildJobDao.saveStep(
+      await db.buildJobDao.upsertBuildStep(
         BuildStep(
           id: 'checkout',
           runId: 'run-456',
@@ -71,7 +71,7 @@ void main() {
         'run-456_checkout',
         'line 1\nline 2\n',
       );
-      await db.buildJobDao.saveStep(
+      await db.buildJobDao.upsertBuildStep(
         BuildStep(
           id: 'test',
           runId: 'run-456',

--- a/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
+++ b/apps/openci_server/test/routes/builds/[id]/runs/[runId]/logs_test.dart
@@ -55,8 +55,8 @@ void main() {
     test('returns stored build step logs', () async {
       await _seedBuildJob(db);
       final now = DateTime.now().toUtc();
-      await db.buildJobDao.insertBuildStep(
-        DriftBuildStep(
+      await db.buildJobDao.saveStep(
+        BuildStep(
           id: 'checkout',
           runId: 'run-456',
           name: 'Checkout',
@@ -71,8 +71,8 @@ void main() {
         'run-456_checkout',
         'line 1\nline 2\n',
       );
-      await db.buildJobDao.insertBuildStep(
-        DriftBuildStep(
+      await db.buildJobDao.saveStep(
+        BuildStep(
           id: 'test',
           runId: 'run-456',
           name: 'Test',


### PR DESCRIPTION
共有モデルの BuildStep を直接保存できるよう、BuildJobDao.insertBuildStep(DriftBuildStep) を upsertBuildStep(BuildStep) に変更します。DAO内でDBモデルへ変換し、同じstep IDがある場合は既存行を更新します。

既存のDAOテストで保存フィールドを確認し、ログ取得テストの準備データも新しい呼び出しに対応させます。

検証済み:

- 変更した3ファイルの dart format
- openci_server の dart analyze --fatal-infos .
- build_job_dao_test.dart と runs/[runId]/logs_test.dart の関連13テスト
- git diff --check と差分全体のレビュー

テストにはSQLiteを使用しています。PG実機での検証は未実施です。
